### PR TITLE
[FEAT] Cassandra Entities for Tweet, UserTimeline(Fanout on write), F…

### DIFF
--- a/src/main/java/com/example/demo/domain/celebrity/CelebrityTweet.java
+++ b/src/main/java/com/example/demo/domain/celebrity/CelebrityTweet.java
@@ -1,0 +1,48 @@
+// src/main/java/com/example/demo/domain/celebrity/CelebrityTweet.java
+package com.example.demo.domain.celebrity;
+
+import com.example.demo.domain.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.cassandra.core.mapping.PrimaryKey;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.mapping.Column;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Table("celebrity_tweets")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CelebrityTweet extends BaseEntity {
+
+    /**
+     * 복합 Primary Key
+     * - 인플루언서 ID + 시간 + 트윗ID 조합
+     */
+    @PrimaryKey
+    private CelebrityTweetKey key;
+
+    /**
+     * 트윗 내용
+     * - 인플루언서가 작성한 실제 트윗 텍스트
+     * - tweets 테이블의 원본 데이터를 복사하여 저장 (비정규화)
+     * - 타임라인 병합 시 추가 조회 없이 모든 정보 제공
+     */
+    @Column("tweet_text")
+    private String tweetText;
+
+    /**
+     * 인플루언서 트윗 생성 생성자
+     * @param authorId 인플루언서 ID (파티션 키가 됨)
+     * @param tweetId 트윗 고유 ID (tweets 테이블과 연결)
+     * @param tweetText 트윗 내용
+     */
+    public CelebrityTweet(UUID authorId, UUID tweetId, String tweetText) {
+        this.key = new CelebrityTweetKey(authorId, LocalDateTime.now(), tweetId);
+        this.tweetText = tweetText;
+        // createdAt, modifiedAt은 BaseEntity에서 자동 관리
+    }
+}

--- a/src/main/java/com/example/demo/domain/celebrity/CelebrityTweetKey.java
+++ b/src/main/java/com/example/demo/domain/celebrity/CelebrityTweetKey.java
@@ -1,0 +1,47 @@
+// src/main/java/com/example/demo/domain/celebrity/CelebrityTweetKey.java
+package com.example.demo.domain.celebrity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.cassandra.core.cql.Ordering;
+import org.springframework.data.cassandra.core.cql.PrimaryKeyType;
+import org.springframework.data.cassandra.core.mapping.PrimaryKeyClass;
+import org.springframework.data.cassandra.core.mapping.PrimaryKeyColumn;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@PrimaryKeyClass
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CelebrityTweetKey implements Serializable {
+
+    /**
+     * 인플루언서/셀럽 ID (파티션 키)
+     * - 특정 인플루언서의 모든 트윗이 한 파티션에 저장됨
+     * - 팔로워 수가 많아 Fan-out on Write가 비효율적인 사용자들
+     */
+    @PrimaryKeyColumn(name = "author_id", type = PrimaryKeyType.PARTITIONED)
+    private UUID authorId;
+
+    /**
+     * 트윗 생성 시간 (첫 번째 클러스터링 키, 내림차순)
+     * - 최신 트윗부터 조회되도록 DESC 정렬
+     * - 타임라인 병합 시 시간 기준으로 정렬에 활용
+     */
+    @PrimaryKeyColumn(name = "created_at", type = PrimaryKeyType.CLUSTERED, ordering = Ordering.DESCENDING)
+    private LocalDateTime createdAt;
+
+    /**
+     * 트윗 고유 ID (두 번째 클러스터링 키)
+     * - 동일한 created_at을 가진 트윗들의 고유성 보장
+     * - tweets 테이블의 원본 트윗과 연결되는 참조 키
+     */
+    @PrimaryKeyColumn(name = "tweet_id", type = PrimaryKeyType.CLUSTERED)
+    private UUID tweetId;
+}

--- a/src/main/java/com/example/demo/domain/follow/FollowersByUser.java
+++ b/src/main/java/com/example/demo/domain/follow/FollowersByUser.java
@@ -1,0 +1,46 @@
+// src/main/java/com/example/demo/domain/follow/FollowersByUser.java
+package com.example.demo.domain.follow;
+
+import com.example.demo.domain.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.cassandra.core.mapping.PrimaryKey;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.mapping.Column;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Table("followers_by_user")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FollowersByUser extends BaseEntity {
+
+    /**
+     * 복합 Primary Key
+     * - followed_user_id + follower_id 조합으로 고유성 보장
+     */
+    @PrimaryKey
+    private FollowersByUserKey key;
+
+    /**
+     * 팔로우 시작 시간
+     * - 언제부터 팔로우 관계가 시작되었는지 기록
+     * - 팔로우 순서나 통계 분석에 활용 가능
+     */
+    @Column("followed_at")
+    private LocalDateTime followedAt;
+
+    /**
+     * 팔로우 관계 생성 생성자
+     * @param followedUserId 팔로우 당하는 사용자 ID  
+     * @param followerId 팔로우 하는 사용자 ID
+     */
+    public FollowersByUser(UUID followedUserId, UUID followerId) {
+        this.key = new FollowersByUserKey(followedUserId, followerId);
+        this.followedAt = LocalDateTime.now();
+        // createdAt, modifiedAt은 BaseEntity에서 자동 관리
+    }
+}

--- a/src/main/java/com/example/demo/domain/follow/FollowersByUserKey.java
+++ b/src/main/java/com/example/demo/domain/follow/FollowersByUserKey.java
@@ -1,0 +1,37 @@
+// src/main/java/com/example/demo/domain/follow/FollowersByUserKey.java
+package com.example.demo.domain.follow;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.cassandra.core.cql.PrimaryKeyType;
+import org.springframework.data.cassandra.core.mapping.PrimaryKeyClass;
+import org.springframework.data.cassandra.core.mapping.PrimaryKeyColumn;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@PrimaryKeyClass
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowersByUserKey implements Serializable {
+
+    /**
+     * 팔로우 당하는 사용자 ID (파티션 키)
+     * - 이 값이 같은 모든 레코드는 동일한 Cassandra 노드에 저장됨
+     * - "누구의 팔로워 목록인가?"를 나타내는 기준
+     */
+    @PrimaryKeyColumn(name = "followed_user_id", type = PrimaryKeyType.PARTITIONED)
+    private UUID followedUserId;
+
+    /**
+     * 팔로우 하는 사용자 ID (클러스터링 키)
+     * - 같은 파티션 내에서 이 값으로 정렬됨
+     * - 중복 방지: 같은 사람이 같은 사람을 두 번 팔로우할 수 없음
+     */
+    @PrimaryKeyColumn(name = "follower_id", type = PrimaryKeyType.CLUSTERED)
+    private UUID followerId;
+}

--- a/src/main/java/com/example/demo/domain/timeline/UserTimeline.java
+++ b/src/main/java/com/example/demo/domain/timeline/UserTimeline.java
@@ -1,0 +1,61 @@
+// src/main/java/com/example/demo/domain/timeline/UserTimeline.java
+package com.example.demo.domain.timeline;
+
+import com.example.demo.domain.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.cassandra.core.mapping.PrimaryKey;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.mapping.Column;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+
+ */
+@Table("user_timeline")
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserTimeline extends BaseEntity {
+
+    /**
+     * 복합 Primary Key
+     * - 타임라인 소유자 + 시간 + 트윗ID 조합
+     */
+    @PrimaryKey
+    private UserTimelineKey key;
+
+    /**
+     * 트윗 작성자 ID
+     * - 이 트윗을 누가 작성했는지 식별
+     * - 타임라인에서 "누구의 트윗인지" 표시하는 용도
+     */
+    @Column("author_id")
+    private UUID authorId;
+
+    /**
+     * 트윗 내용
+     * - 실제 트윗 텍스트 내용
+     * - tweets 테이블의 원본 데이터를 복사하여 저장 (비정규화)
+     * - 타임라인 조회 시 추가 조인 없이 모든 정보 제공
+     */
+    @Column("tweet_text")
+    private String tweetText;
+
+    /**
+     * 타임라인 엔트리 생성 생성자
+     * @param followerId 타임라인 소유자 ID (이 사용자의 타임라인에 추가됨)
+     * @param tweetId 트윗 고유 ID
+     * @param authorId 트윗 작성자 ID
+     * @param tweetText 트윗 내용
+     */
+    public UserTimeline(UUID followerId, UUID tweetId, UUID authorId, String tweetText) {
+        this.key = new UserTimelineKey(followerId, LocalDateTime.now(), tweetId);
+        this.authorId = authorId;
+        this.tweetText = tweetText;
+        // createdAt, modifiedAt은 BaseEntity에서 자동 관리
+    }
+}

--- a/src/main/java/com/example/demo/domain/timeline/UserTimelineKey.java
+++ b/src/main/java/com/example/demo/domain/timeline/UserTimelineKey.java
@@ -1,0 +1,47 @@
+// src/main/java/com/example/demo/domain/timeline/UserTimelineKey.java
+package com.example.demo.domain.timeline;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.cassandra.core.cql.Ordering;
+import org.springframework.data.cassandra.core.cql.PrimaryKeyType;
+import org.springframework.data.cassandra.core.mapping.PrimaryKeyClass;
+import org.springframework.data.cassandra.core.mapping.PrimaryKeyColumn;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@PrimaryKeyClass
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserTimelineKey implements Serializable {
+
+    /**
+     * 타임라인 소유자 ID (파티션 키)
+     * - 이 사용자가 보게 될 타임라인을 의미
+     * - 각 사용자의 타임라인이 별도 파티션에 저장됨
+     */
+    @PrimaryKeyColumn(name = "follower_id", type = PrimaryKeyType.PARTITIONED)
+    private UUID followerId;
+
+    /**
+     * 트윗 생성 시간 (첫 번째 클러스터링 키, 내림차순)
+     * - 타임라인에서 최신 트윗부터 보이도록 DESC 정렬
+     * - 페이지네이션의 커서 역할
+     */
+    @PrimaryKeyColumn(name = "created_at", type = PrimaryKeyType.CLUSTERED, ordering = Ordering.DESCENDING)
+    private LocalDateTime createdAt;
+
+    /**
+     * 트윗 고유 ID (두 번째 클러스터링 키)
+     * - 동일한 created_at을 가진 트윗들의 고유성 보장
+     * - 정확한 커서 기반 페이지네이션 지원
+     */
+    @PrimaryKeyColumn(name = "tweet_id", type = PrimaryKeyType.CLUSTERED)
+    private UUID tweetId;
+}

--- a/src/main/java/com/example/demo/domain/tweet/Tweet.java
+++ b/src/main/java/com/example/demo/domain/tweet/Tweet.java
@@ -1,0 +1,55 @@
+package com.example.demo.domain.tweet;
+
+import com.example.demo.domain.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.PrimaryKey;
+import org.springframework.data.cassandra.core.mapping.Table;
+
+import java.util.UUID;
+
+@Table("tweets")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Tweet extends BaseEntity {
+
+    /**
+     * 트윗 고유 식별자 (Primary Key)
+     * - UUID로 글로벌 고유성 보장
+     * - 파티션 키로 사용되어 특정 트윗에 직접 접근 가능
+     */
+    @PrimaryKey
+    @Column("tweet_id")
+    private UUID tweetId;
+
+    /**
+     * 트윗 작성자 ID
+     * - 어떤 사용자가 이 트윗을 작성했는지 식별
+     * - Fan-out 과정에서 author 정보로 활용
+     */
+    @Column("user_id")
+    private UUID userId;
+
+    /**
+     * 트윗 내용
+     * - 실제 사용자가 작성한 텍스트 내용
+     * - 최대 길이 제한은 애플리케이션 레벨에서 검증
+     */
+    @Column("tweet_text")
+    private String tweetText;
+
+    /**
+     * 트윗 생성 생성자
+     * @param userId 트윗 작성자 ID
+     * @param tweetText 트윗 내용
+     */
+    public Tweet(UUID userId, String tweetText) {
+        this.tweetId = UUID.randomUUID(); // 자동으로 고유 ID 생성
+        this.userId = userId;
+        this.tweetText = tweetText;
+    }
+}


### PR DESCRIPTION
# Tweet 서비스 테이블 설명 문서

## 📦 Table Overview

- Tweet
- UserTimeline
- UserTimelineKey
- FollowersByUser
- FollowersByUserKey
- CelebrityTweet
- CelebrityTweetKey


<details>
<summary>🐦 <strong>Tweet</strong> (트윗 원본 저장소)</summary>

📋 **역할**  
- 사용자가 작성한 모든 트윗의 원본  
- 트윗 작성 API에서 원본 데이터를 저장하는 메인 테이블  
- 다른 서비스에서 `tweet_id`로 트윗 상세 정보를 조회할 때 사용  

🗂️ **테이블 구조**  
- PRIMARY KEY: `tweet_id` (단일 파티션 키)  
- `tweet_id`로 개별 트윗에 O(1) 빠른 접근 가능  
- UUID 사용으로 분산 환경에서 고유성 보장  

🔍 **주요 사용 패턴**  
- `POST /tweets`: 새 트윗 저장  
- `GET /tweets/{tweetId}`: 특정 트윗 조회  
- 메시지 브로커로 트윗 생성 이벤트 발행 시 원본 데이터 제공  

⚠️ **주의사항**  
- 이 테이블은 `user_id`로 직접 조회하지 않음 (다른 테이블에서 담당)  
- 트윗 삭제 시에도 이 테이블에서 완전 삭제하지 않고 상태값으로 관리 권장  

</details>


<details>
<summary>📱 <strong>UserTimeline</strong> (개인 타임라인 테이블)</summary>

📋 **역할**  
- 각 사용자가 보게 될 개인 타임라인을 미리 생성하여 저장  
- 타임라인 조회 API에서 매우 빠른 읽기 성능 제공  
- Fan-out on Write 전략의 핵심 테이블  

🏗️ **테이블 구조**  
- PRIMARY KEY: (`follower_id`, `created_at` DESC, `tweet_id`)  
  - `follower_id`: 파티션 키 (타임라인 소유자)  
  - `created_at`: 첫 번째 클러스터링 키 (시간순 정렬)  
  - `tweet_id`: 두 번째 클러스터링 키 (고유성 보장)  

🔄 **Fan-out on Write 과정**  
1. `user-A`가 트윗 작성  
2. `user-A`의 팔로워 목록 조회  
3. 각 팔로워의 타임라인에 트윗 저장  

💾 **데이터 예시**  
| follower_id | created_at          | tweet_id  | author_id | tweet_text    |
|-------------|---------------------|-----------|-----------|---------------|
| user-1      | 2025-01-15 14:30:00 | tweet-123 | user-A    | 안녕하세요      |
| user-1      | 2025-01-15 14:25:00 | tweet-122 | user-B    | 점심 맛있다     |
| user-1      | 2025-01-15 14:20:00 | tweet-121 | user-C    | 날씨가 좋네요   |

⚡ **성능 특징**  
- 타임라인 조회: O(1) + 조회할 트윗 수  
- 쓰기 시 팬아웃 비용 발생  
- 인플루언서는 `celebrity_tweets` 테이블 사용  

⚠️ **주의사항**  
- 일반 사용자 전용  
- 트윗 삭제 시 모든 타임라인에서도 삭제 필요  

</details>


<details>
<summary>🔑 <strong>UserTimelineKey</strong> (개인 타임라인 복합 Primary Key)</summary>

🎯 **목적**  
- 특정 사용자의 타임라인을 시간순으로 정렬하여 저장하기 위한 복합 키  

🗝️ **Key 구성**  
1. `follower_id` (파티션 키)  
2. `created_at` (클러스터링 키, DESC)  
3. `tweet_id` (클러스터링 키)  

🔍 **쿼리 패턴**  
- 최신 20개 조회: `WHERE follower_id = 'user-1' ORDER BY created_at DESC LIMIT 20`  
- 커서 페이지네이션: `WHERE follower_id = 'user-1' AND created_at < '마지막 시간' LIMIT 20`  

</details>


<details>
<summary>👥 <strong>FollowersByUser</strong> (팔로우 관계 테이블)</summary>

📋 **역할**  
- 특정 사용자를 팔로우하는 사용자 목록 저장  
- Fan-out on Write 시 팔로워 조회용  
- 팔로우/언팔로우 기능 처리  

🏗️ **테이블 구조**  
- PRIMARY KEY: (`followed_user_id`, `follower_id`)  

🔍 **주요 사용 패턴**  
- `WHERE followed_user_id = 'user-A'` → 팔로워 목록 조회  
- `POST /follow/{userId}`, `DELETE /follow/{userId}`  

💾 **데이터 예시**  
| followed_user_id | follower_id | followed_at         |
|------------------|-------------|---------------------|
| user-A           | user-1      | 2025-01-15 10:00:00 |
| user-A           | user-2      | 2025-01-15 11:00:00 |
| user-A           | user-3      | 2025-01-15 12:00:00 |

⚡ **성능 특징**  
- 팔로워 조회: O(1) + 팔로워 수  
- 대용량 사용자도 효율적으로 처리 가능  

</details>


<details>
<summary>🔑 <strong>FollowersByUserKey</strong> (팔로우 관계 복합 Primary Key)</summary>

🎯 **목적**  
- Cassandra에서 효율적으로 팔로우 관계를 조회하기 위한 복합 키 구조  

🗝️ **Key 구성**  
1. `followed_user_id` (파티션 키)  
2. `follower_id` (클러스터링 키)  

🔍 **쿼리 패턴**  
- `WHERE followed_user_id = 'user-A'` → user-A의 팔로워 전체 조회  

💡 **팁**  
- 파티션 키는 데이터를 어느 노드에 저장할지 결정  
- 클러스터링 키는 파티션 내 정렬 순서 결정  

</details>


<details>
<summary>🌟 <strong>CelebrityTweet</strong> (인플루언서 트윗 테이블)</summary>

📋 **역할**  
- 팔로워 수 많은 셀럽의 트윗만 별도로 저장  
- Fan-out on Write 비용 절감을 위한 전략  
- 타임라인 조회 시 실시간 병합  

🏗️ **테이블 구조**  
- PRIMARY KEY: (`author_id`, `created_at` DESC, `tweet_id`)  

🔍 **사용 시나리오**  
1. 트윗 작성 → `tweets` + `celebrity_tweets`에 저장  
2. 타임라인 조회 시 `celebrity_tweets`에서 조회 후 병합  

💾 **데이터 예시**  
| author_id | created_at          | tweet_id  | tweet_text        |
|-----------|---------------------|-----------|-------------------|
| 아이유-id  | 2025-01-15 14:30:00 | tweet-456 | 새 앨범 발매했어요! |
| 아이유-id  | 2025-01-15 12:15:00 | tweet-455 | 콘서트 재밌었어요   |
| 아이유-id  | 2025-01-15 10:20:00 | tweet-454 | 좋은 아침이에요    |

⚡ **성능 특징**  
- 쓰기 비용: O(1)  
- 읽기 성능: 병합 오버헤드 있음  
- 저장 공간: 중복 최소화  

🎯 **인플루언서 기준**  
- 팔로워 수 > 10,000명 또는 VIP 계정  

⚠️ **주의사항**  
- 병합 로직 최적화 필수  
- 인플루언서 ↔ 일반 사용자 전환 시 마이그레이션 고려  

</details>


<details>
<summary>🔑 <strong>CelebrityTweetKey</strong> (인플루언서 트윗 복합 Primary Key)</summary>

🎯 **목적**  
- 인플루언서 트윗을 효율적으로 저장 및 조회하기 위한 복합 키  

🗝️ **Key 구성**  
1. `author_id` (파티션 키)  
2. `created_at` (클러스터링 키, DESC)  
3. `tweet_id` (클러스터링 키)  

🔍 **쿼리 패턴**  
- `WHERE author_id = '아이유-id' ORDER BY created_at DESC LIMIT 10`  
- 타임라인 조회 시 일반 트윗과 병합  

💡 **Fan-out on Read 과정**  
1. `GET /timeline` 요청  
2. `user_timeline`에서 일반 트윗 조회  
3. `celebrity_tweets`에서 셀럽 트윗 조회  
4. 두 결과 병합 후 응답  

</details>
