### PR TITLE
[FIX] 당장 사용되지 않는 Cassandra Repository 메서드 삭제

### DIFF
--- a/src/main/java/com/example/demo/domain/CassandraBaseEntity.java
+++ b/src/main/java/com/example/demo/domain/CassandraBaseEntity.java
@@ -1,0 +1,20 @@
+package com.example.demo.domain;
+
+import lombok.Getter;
+import org.springframework.data.cassandra.core.mapping.Column;
+
+import java.time.LocalDateTime;
+
+@Getter
+public abstract class CassandraBaseEntity {
+
+    @Column("created_at")
+    protected LocalDateTime createdAt;
+
+    /**
+     * 생성 시간 설정
+     */
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/example/demo/domain/MySqlBaseEntity.java
+++ b/src/main/java/com/example/demo/domain/MySqlBaseEntity.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
+public abstract class MySqlBaseEntity {
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/demo/domain/celebrity/CelebrityTweet.java
+++ b/src/main/java/com/example/demo/domain/celebrity/CelebrityTweet.java
@@ -1,7 +1,7 @@
-// src/main/java/com/example/demo/domain/celebrity/CelebrityTweet.java
+
 package com.example.demo.domain.celebrity;
 
-import com.example.demo.domain.BaseEntity;
+import com.example.demo.domain.CassandraBaseEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,7 +16,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
-public class CelebrityTweet extends BaseEntity {
+public class CelebrityTweet extends CassandraBaseEntity {
 
     /**
      * 복합 Primary Key
@@ -40,9 +40,9 @@ public class CelebrityTweet extends BaseEntity {
      * @param tweetId 트윗 고유 ID (tweets 테이블과 연결)
      * @param tweetText 트윗 내용
      */
-    public CelebrityTweet(UUID authorId, UUID tweetId, String tweetText) {
-        this.key = new CelebrityTweetKey(authorId, LocalDateTime.now(), tweetId);
+    public CelebrityTweet(UUID authorId, UUID tweetId, String tweetText, LocalDateTime createdAt) {
+        this.key = new CelebrityTweetKey(authorId, createdAt, tweetId);
         this.tweetText = tweetText;
-        // createdAt, modifiedAt은 BaseEntity에서 자동 관리
+        this.setCreatedAt(createdAt);
     }
 }

--- a/src/main/java/com/example/demo/domain/celebrity/CelebrityTweetRepository.java
+++ b/src/main/java/com/example/demo/domain/celebrity/CelebrityTweetRepository.java
@@ -1,0 +1,132 @@
+package com.example.demo.domain.celebrity;
+
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * CelebrityTweet 엔티티를 위한 Cassandra Repository
+ * 
+ * 주요 기능:
+ * - Fan-out on Read 전략용 인플루언서 트윗 저장/조회
+ * - 인플루언서별 시간순 트윗 조회
+ * - 커서 기반 페이지네이션 지원
+ * - 타임라인 병합 시 사용
+ */
+@Repository
+public interface CelebrityTweetRepository extends CassandraRepository<CelebrityTweet, CelebrityTweetKey> {
+
+    /**
+     * 특정 인플루언서의 최신 트윗 조회
+     * 시간순 내림차순으로 정렬되어 있음 (Cassandra 클러스터링 키 활용)
+     * @param authorId 인플루언서 ID
+     * @param limit 조회할 트윗 수
+     * @return 인플루언서 트윗 목록
+     */
+    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 ORDER BY created_at DESC LIMIT ?1")
+    List<CelebrityTweet> findByKeyAuthorIdOrderByKeyCreatedAtDesc(UUID authorId, int limit);
+
+    /**
+     * 커서 기반 페이지네이션 - 특정 시간 이전 트윗 조회
+     * @param authorId 인플루언서 ID
+     * @param cursor 기준 시간 (이 시간 이전 트윗들 조회)
+     * @param limit 조회할 트윗 수
+     * @return 인플루언서 트윗 목록
+     */
+    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 AND created_at < ?1 ORDER BY created_at DESC LIMIT ?2")
+    List<CelebrityTweet> findByKeyAuthorIdAndKeyCreatedAtBefore(UUID authorId, LocalDateTime cursor, int limit);
+
+    /**
+     * 특정 시간 이후의 인플루언서 트윗 조회
+     * (실시간 업데이트 시 사용)
+     * @param authorId 인플루언서 ID
+     * @param cursor 기준 시간 (이 시간 이후 트윗들 조회)
+     * @param limit 조회할 트윗 수
+     * @return 인플루언서 트윗 목록
+     */
+    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 AND created_at > ?1 ORDER BY created_at DESC LIMIT ?2")
+    List<CelebrityTweet> findByKeyAuthorIdAndKeyCreatedAtAfter(UUID authorId, LocalDateTime cursor, int limit);
+
+    /**
+     * 여러 인플루언서의 최신 트윗 조회 (배치)
+     * 타임라인 병합 시 사용
+     * @param authorIds 인플루언서 ID 목록
+     * @param limit 각 인플루언서당 조회할 트윗 수
+     * @return 모든 인플루언서의 트윗 목록
+     */
+    @Query("SELECT * FROM celebrity_tweets WHERE author_id IN ?0 ORDER BY author_id, created_at DESC LIMIT ?1")
+    List<CelebrityTweet> findByKeyAuthorIdInOrderByKeyCreatedAtDesc(List<UUID> authorIds, int limit);
+
+    /**
+     * 특정 트윗 ID로 인플루언서 트윗 조회
+     * @param authorId 인플루언서 ID
+     * @param tweetId 트윗 ID
+     * @return 인플루언서 트윗 (선택적)
+     */
+    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 AND tweet_id = ?1 ALLOW FILTERING")
+    List<CelebrityTweet> findByKeyAuthorIdAndKeyTweetId(UUID authorId, UUID tweetId);
+
+    /**
+     * 특정 인플루언서 트윗 삭제
+     * @param authorId 인플루언서 ID
+     * @param createdAt 생성 시간
+     * @param tweetId 트윗 ID
+     */
+    @Query("DELETE FROM celebrity_tweets WHERE author_id = ?0 AND created_at = ?1 AND tweet_id = ?2")
+    void deleteByKeyAuthorIdAndKeyCreatedAtAndKeyTweetId(UUID authorId, LocalDateTime createdAt, UUID tweetId);
+
+    /**
+     * 특정 인플루언서의 모든 트윗 삭제
+     * (계정 삭제 또는 인플루언서 해제 시 사용)
+     * @param authorId 인플루언서 ID
+     */
+    @Query("DELETE FROM celebrity_tweets WHERE author_id = ?0")
+    void deleteByKeyAuthorId(UUID authorId);
+
+    /**
+     * 특정 인플루언서의 트윗 수 조회
+     * @param authorId 인플루언서 ID
+     * @return 트윗 수
+     */
+    @Query("SELECT COUNT(*) FROM celebrity_tweets WHERE author_id = ?0")
+    long countByKeyAuthorId(UUID authorId);
+
+    /**
+     * 특정 기간 동안의 인플루언서 트윗 조회
+     * @param authorId 인플루언서 ID
+     * @param startTime 시작 시간
+     * @param endTime 종료 시간
+     * @return 해당 기간의 트윗 목록
+     */
+    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 AND created_at >= ?1 AND created_at <= ?2 ORDER BY created_at DESC")
+    List<CelebrityTweet> findByKeyAuthorIdAndKeyCreatedAtBetween(UUID authorId, LocalDateTime startTime, LocalDateTime endTime);
+
+    /**
+     * 모든 인플루언서의 최신 트윗 조회 (관리자용)
+     * @param limit 조회할 트윗 수
+     * @return 모든 인플루언서의 최신 트윗
+     */
+    @Query("SELECT * FROM celebrity_tweets ORDER BY author_id, created_at DESC LIMIT ?0")
+    List<CelebrityTweet> findAllOrderByKeyCreatedAtDesc(int limit);
+
+    /**
+     * 인플루언서별 트윗 통계 조회
+     * (인기도 분석용)
+     * @return 인플루언서 ID와 트윗 수 매핑
+     */
+    @Query("SELECT author_id, COUNT(*) as tweet_count FROM celebrity_tweets GROUP BY author_id")
+    List<Object[]> getCelebrityTweetStats();
+
+    /**
+     * 특정 시간 이후 모든 인플루언서 트윗 조회
+     * (시스템 복구 시 사용)
+     * @param timestamp 기준 시간
+     * @return 해당 시간 이후의 모든 인플루언서 트윗
+     */
+    @Query("SELECT * FROM celebrity_tweets WHERE created_at > ?0 ALLOW FILTERING")
+    List<CelebrityTweet> findAllByKeyCreatedAtAfter(LocalDateTime timestamp);
+} 

--- a/src/main/java/com/example/demo/domain/celebrity/CelebrityTweetRepository.java
+++ b/src/main/java/com/example/demo/domain/celebrity/CelebrityTweetRepository.java
@@ -10,52 +10,25 @@ import java.util.UUID;
 
 /**
  * CelebrityTweet 엔티티를 위한 Cassandra Repository
- * 
- * API 지원 기능:
- * - GET /timeline: 타임라인 조회 시 인플루언서 트윗 병합
- * - Fan-out on Read 전략 (Celebrity Problem 해결)
+ * Celebrity Problem 해결을 위한 Fan-out on Read 전략
  */
 @Repository
 public interface CelebrityTweetRepository extends CassandraRepository<CelebrityTweet, CelebrityTweetKey> {
 
     /**
      * 특정 인플루언서의 최신 트윗 조회
-     * Fan-out on Read 시 사용
      * @param authorId 인플루언서 ID
-     * @param limit 조회할 트윗 수
-     * @return 시간순 정렬된 인플루언서 트윗 목록
+     * @return 최신순 트윗 목록 (최대 20개)
      */
-    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 ORDER BY created_at DESC LIMIT ?1")
-    List<CelebrityTweet> findByKeyAuthorIdOrderByKeyCreatedAtDesc(UUID authorId, int limit);
+    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 LIMIT 20")
+    List<CelebrityTweet> findLatestTweets(UUID authorId);
 
     /**
-     * 커서 기반 페이지네이션 - 특정 시간 이전 트윗 조회
-     * 타임라인 병합 시 사용
+     * 커서 기반 페이지네이션
      * @param authorId 인플루언서 ID
      * @param cursor 기준 시간
-     * @param limit 조회할 트윗 수
-     * @return 인플루언서 트윗 목록
+     * @return 트윗 목록
      */
-    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 AND created_at < ?1 ORDER BY created_at DESC LIMIT ?2")
-    List<CelebrityTweet> findByKeyAuthorIdAndKeyCreatedAtBefore(UUID authorId, LocalDateTime cursor, int limit);
-
-    /**
-     * 여러 인플루언서의 최신 트윗 배치 조회
-     * 타임라인 병합 시 성능 최적화
-     * @param authorIds 인플루언서 ID 목록
-     * @param limit 각 인플루언서당 조회할 트윗 수
-     * @return 모든 인플루언서의 트윗 목록
-     */
-    @Query("SELECT * FROM celebrity_tweets WHERE author_id IN ?0 ORDER BY author_id, created_at DESC LIMIT ?1")
-    List<CelebrityTweet> findByKeyAuthorIdInOrderByKeyCreatedAtDesc(List<UUID> authorIds, int limit);
-
-    /**
-     * 특정 인플루언서 트윗 삭제
-     * 트윗 삭제 시 사용
-     * @param authorId 인플루언서 ID
-     * @param createdAt 생성 시간
-     * @param tweetId 트윗 ID
-     */
-    @Query("DELETE FROM celebrity_tweets WHERE author_id = ?0 AND created_at = ?1 AND tweet_id = ?2")
-    void deleteByKeyAuthorIdAndKeyCreatedAtAndKeyTweetId(UUID authorId, LocalDateTime createdAt, UUID tweetId);
+    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 AND created_at < ?1 LIMIT 20")
+    List<CelebrityTweet> findTweetsWithCursor(UUID authorId, LocalDateTime cursor);
 } 

--- a/src/main/java/com/example/demo/domain/celebrity/CelebrityTweetRepository.java
+++ b/src/main/java/com/example/demo/domain/celebrity/CelebrityTweetRepository.java
@@ -11,29 +11,28 @@ import java.util.UUID;
 /**
  * CelebrityTweet 엔티티를 위한 Cassandra Repository
  * 
- * 주요 기능:
- * - Fan-out on Read 전략용 인플루언서 트윗 저장/조회
- * - 인플루언서별 시간순 트윗 조회
- * - 커서 기반 페이지네이션 지원
- * - 타임라인 병합 시 사용
+ * API 지원 기능:
+ * - GET /timeline: 타임라인 조회 시 인플루언서 트윗 병합
+ * - Fan-out on Read 전략 (Celebrity Problem 해결)
  */
 @Repository
 public interface CelebrityTweetRepository extends CassandraRepository<CelebrityTweet, CelebrityTweetKey> {
 
     /**
      * 특정 인플루언서의 최신 트윗 조회
-     * 시간순 내림차순으로 정렬되어 있음 (Cassandra 클러스터링 키 활용)
+     * Fan-out on Read 시 사용
      * @param authorId 인플루언서 ID
      * @param limit 조회할 트윗 수
-     * @return 인플루언서 트윗 목록
+     * @return 시간순 정렬된 인플루언서 트윗 목록
      */
     @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 ORDER BY created_at DESC LIMIT ?1")
     List<CelebrityTweet> findByKeyAuthorIdOrderByKeyCreatedAtDesc(UUID authorId, int limit);
 
     /**
      * 커서 기반 페이지네이션 - 특정 시간 이전 트윗 조회
+     * 타임라인 병합 시 사용
      * @param authorId 인플루언서 ID
-     * @param cursor 기준 시간 (이 시간 이전 트윗들 조회)
+     * @param cursor 기준 시간
      * @param limit 조회할 트윗 수
      * @return 인플루언서 트윗 목록
      */
@@ -41,19 +40,8 @@ public interface CelebrityTweetRepository extends CassandraRepository<CelebrityT
     List<CelebrityTweet> findByKeyAuthorIdAndKeyCreatedAtBefore(UUID authorId, LocalDateTime cursor, int limit);
 
     /**
-     * 특정 시간 이후의 인플루언서 트윗 조회
-     * (실시간 업데이트 시 사용)
-     * @param authorId 인플루언서 ID
-     * @param cursor 기준 시간 (이 시간 이후 트윗들 조회)
-     * @param limit 조회할 트윗 수
-     * @return 인플루언서 트윗 목록
-     */
-    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 AND created_at > ?1 ORDER BY created_at DESC LIMIT ?2")
-    List<CelebrityTweet> findByKeyAuthorIdAndKeyCreatedAtAfter(UUID authorId, LocalDateTime cursor, int limit);
-
-    /**
-     * 여러 인플루언서의 최신 트윗 조회 (배치)
-     * 타임라인 병합 시 사용
+     * 여러 인플루언서의 최신 트윗 배치 조회
+     * 타임라인 병합 시 성능 최적화
      * @param authorIds 인플루언서 ID 목록
      * @param limit 각 인플루언서당 조회할 트윗 수
      * @return 모든 인플루언서의 트윗 목록
@@ -62,71 +50,12 @@ public interface CelebrityTweetRepository extends CassandraRepository<CelebrityT
     List<CelebrityTweet> findByKeyAuthorIdInOrderByKeyCreatedAtDesc(List<UUID> authorIds, int limit);
 
     /**
-     * 특정 트윗 ID로 인플루언서 트윗 조회
-     * @param authorId 인플루언서 ID
-     * @param tweetId 트윗 ID
-     * @return 인플루언서 트윗 (선택적)
-     */
-    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 AND tweet_id = ?1 ALLOW FILTERING")
-    List<CelebrityTweet> findByKeyAuthorIdAndKeyTweetId(UUID authorId, UUID tweetId);
-
-    /**
      * 특정 인플루언서 트윗 삭제
+     * 트윗 삭제 시 사용
      * @param authorId 인플루언서 ID
      * @param createdAt 생성 시간
      * @param tweetId 트윗 ID
      */
     @Query("DELETE FROM celebrity_tweets WHERE author_id = ?0 AND created_at = ?1 AND tweet_id = ?2")
     void deleteByKeyAuthorIdAndKeyCreatedAtAndKeyTweetId(UUID authorId, LocalDateTime createdAt, UUID tweetId);
-
-    /**
-     * 특정 인플루언서의 모든 트윗 삭제
-     * (계정 삭제 또는 인플루언서 해제 시 사용)
-     * @param authorId 인플루언서 ID
-     */
-    @Query("DELETE FROM celebrity_tweets WHERE author_id = ?0")
-    void deleteByKeyAuthorId(UUID authorId);
-
-    /**
-     * 특정 인플루언서의 트윗 수 조회
-     * @param authorId 인플루언서 ID
-     * @return 트윗 수
-     */
-    @Query("SELECT COUNT(*) FROM celebrity_tweets WHERE author_id = ?0")
-    long countByKeyAuthorId(UUID authorId);
-
-    /**
-     * 특정 기간 동안의 인플루언서 트윗 조회
-     * @param authorId 인플루언서 ID
-     * @param startTime 시작 시간
-     * @param endTime 종료 시간
-     * @return 해당 기간의 트윗 목록
-     */
-    @Query("SELECT * FROM celebrity_tweets WHERE author_id = ?0 AND created_at >= ?1 AND created_at <= ?2 ORDER BY created_at DESC")
-    List<CelebrityTweet> findByKeyAuthorIdAndKeyCreatedAtBetween(UUID authorId, LocalDateTime startTime, LocalDateTime endTime);
-
-    /**
-     * 모든 인플루언서의 최신 트윗 조회 (관리자용)
-     * @param limit 조회할 트윗 수
-     * @return 모든 인플루언서의 최신 트윗
-     */
-    @Query("SELECT * FROM celebrity_tweets ORDER BY author_id, created_at DESC LIMIT ?0")
-    List<CelebrityTweet> findAllOrderByKeyCreatedAtDesc(int limit);
-
-    /**
-     * 인플루언서별 트윗 통계 조회
-     * (인기도 분석용)
-     * @return 인플루언서 ID와 트윗 수 매핑
-     */
-    @Query("SELECT author_id, COUNT(*) as tweet_count FROM celebrity_tweets GROUP BY author_id")
-    List<Object[]> getCelebrityTweetStats();
-
-    /**
-     * 특정 시간 이후 모든 인플루언서 트윗 조회
-     * (시스템 복구 시 사용)
-     * @param timestamp 기준 시간
-     * @return 해당 시간 이후의 모든 인플루언서 트윗
-     */
-    @Query("SELECT * FROM celebrity_tweets WHERE created_at > ?0 ALLOW FILTERING")
-    List<CelebrityTweet> findAllByKeyCreatedAtAfter(LocalDateTime timestamp);
 } 

--- a/src/main/java/com/example/demo/domain/follow/FollowRepository.java
+++ b/src/main/java/com/example/demo/domain/follow/FollowRepository.java
@@ -9,48 +9,24 @@ import java.util.UUID;
 
 /**
  * FollowersByUser 엔티티를 위한 Cassandra Repository
- * 
- * API 지원 기능:
- * - POST /follow/{userId}: 팔로우 생성
- * - DELETE /follow/{userId}: 팔로우 삭제
- * - Fan-out on Write 지원
+ * Fan-out on Write 지원을 위한 팔로워 조회
  */
 @Repository
 public interface FollowRepository extends CassandraRepository<FollowersByUser, FollowersByUserKey> {
 
     /**
-     * 특정 사용자의 모든 팔로워 ID 조회
-     * Fan-out on Write에서 핵심적으로 사용
+     * 특정 사용자의 팔로워 ID 목록 조회 (Fan-out on Write 핵심)
      * @param followedUserId 팔로우 당하는 사용자 ID
      * @return 팔로워 ID 목록
      */
     @Query("SELECT follower_id FROM followers_by_user WHERE followed_user_id = ?0")
-    List<UUID> findFollowerIdsByFollowedUserId(UUID followedUserId);
+    List<UUID> findFollowerIds(UUID followedUserId);
 
     /**
      * 팔로우 관계 존재 여부 확인
-     * 중복 팔로우 방지용
      * @param followedUserId 팔로우 당하는 사용자 ID
      * @param followerId 팔로우 하는 사용자 ID
-     * @return 팔로우 관계 존재 여부
+     * @return 존재 여부
      */
-    @Query("SELECT COUNT(*) FROM followers_by_user WHERE followed_user_id = ?0 AND follower_id = ?1")
     boolean existsByKeyFollowedUserIdAndKeyFollowerId(UUID followedUserId, UUID followerId);
-
-    /**
-     * 팔로워 수 조회
-     * 인플루언서 판단 기준
-     * @param followedUserId 팔로우 당하는 사용자 ID
-     * @return 팔로워 수
-     */
-    @Query("SELECT COUNT(*) FROM followers_by_user WHERE followed_user_id = ?0")
-    long countByKeyFollowedUserId(UUID followedUserId);
-
-    /**
-     * 팔로우 관계 삭제 (언팔로우)
-     * @param followedUserId 팔로우 당하는 사용자 ID
-     * @param followerId 팔로우 하는 사용자 ID
-     */
-    @Query("DELETE FROM followers_by_user WHERE followed_user_id = ?0 AND follower_id = ?1")
-    void deleteByKeyFollowedUserIdAndKeyFollowerId(UUID followedUserId, UUID followerId);
 } 

--- a/src/main/java/com/example/demo/domain/follow/FollowRepository.java
+++ b/src/main/java/com/example/demo/domain/follow/FollowRepository.java
@@ -1,0 +1,90 @@
+package com.example.demo.domain.follow;
+
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * FollowersByUser 엔티티를 위한 Cassandra Repository
+ * 
+ * 주요 기능:
+ * - 팔로우 관계 생성/삭제
+ * - 특정 사용자의 모든 팔로워 조회 (Fan-out on Write에서 핵심)
+ * - 팔로우 관계 존재 여부 확인
+ * - 팔로워 수 카운팅
+ */
+@Repository
+public interface FollowRepository extends CassandraRepository<FollowersByUser, FollowersByUserKey> {
+
+    /**
+     * 특정 사용자의 모든 팔로워 조회
+     * Fan-out on Write에서 핵심적으로 사용되는 쿼리
+     * @param followedUserId 팔로우 당하는 사용자 ID
+     * @return 팔로워 목록
+     */
+    @Query("SELECT * FROM followers_by_user WHERE followed_user_id = ?0")
+    List<FollowersByUser> findByKeyFollowedUserId(UUID followedUserId);
+
+    /**
+     * 특정 사용자의 팔로워 ID 목록만 조회 (성능 최적화)
+     * @param followedUserId 팔로우 당하는 사용자 ID
+     * @return 팔로워 ID 목록
+     */
+    @Query("SELECT follower_id FROM followers_by_user WHERE followed_user_id = ?0")
+    List<UUID> findFollowerIdsByFollowedUserId(UUID followedUserId);
+
+    /**
+     * 팔로우 관계 존재 여부 확인
+     * @param followedUserId 팔로우 당하는 사용자 ID
+     * @param followerId 팔로우 하는 사용자 ID
+     * @return 팔로우 관계 존재 여부
+     */
+    @Query("SELECT COUNT(*) FROM followers_by_user WHERE followed_user_id = ?0 AND follower_id = ?1")
+    boolean existsByKeyFollowedUserIdAndKeyFollowerId(UUID followedUserId, UUID followerId);
+
+    /**
+     * 팔로워 수 카운팅
+     * 인플루언서 판단 기준으로 사용
+     * @param followedUserId 팔로우 당하는 사용자 ID
+     * @return 팔로워 수
+     */
+    @Query("SELECT COUNT(*) FROM followers_by_user WHERE followed_user_id = ?0")
+    long countByKeyFollowedUserId(UUID followedUserId);
+
+    /**
+     * 특정 기간 이후의 팔로워 조회
+     * @param followedUserId 팔로우 당하는 사용자 ID
+     * @param followedAt 기준 시간
+     * @return 해당 기간 이후 팔로워 목록
+     */
+    @Query("SELECT * FROM followers_by_user WHERE followed_user_id = ?0 AND followed_at >= ?1 ALLOW FILTERING")
+    List<FollowersByUser> findByKeyFollowedUserIdAndFollowedAtAfter(UUID followedUserId, LocalDateTime followedAt);
+
+    /**
+     * 팔로우 관계 삭제 (언팔로우)
+     * @param followedUserId 팔로우 당하는 사용자 ID
+     * @param followerId 팔로우 하는 사용자 ID
+     */
+    @Query("DELETE FROM followers_by_user WHERE followed_user_id = ?0 AND follower_id = ?1")
+    void deleteByKeyFollowedUserIdAndKeyFollowerId(UUID followedUserId, UUID followerId);
+
+    /**
+     * 특정 사용자의 모든 팔로워 관계 삭제
+     * (계정 삭제 시 사용)
+     * @param followedUserId 팔로우 당하는 사용자 ID
+     */
+    @Query("DELETE FROM followers_by_user WHERE followed_user_id = ?0")
+    void deleteByKeyFollowedUserId(UUID followedUserId);
+
+    /**
+     * 팔로워 수 기준으로 인플루언서 후보 조회
+     * @param minFollowerCount 최소 팔로워 수
+     * @return 인플루언서 후보 사용자 ID 목록
+     */
+    @Query("SELECT followed_user_id FROM followers_by_user GROUP BY followed_user_id HAVING COUNT(*) >= ?0 ALLOW FILTERING")
+    List<UUID> findUsersWithMinFollowers(long minFollowerCount);
+} 

--- a/src/main/java/com/example/demo/domain/follow/FollowRepository.java
+++ b/src/main/java/com/example/demo/domain/follow/FollowRepository.java
@@ -4,33 +4,23 @@ import org.springframework.data.cassandra.repository.CassandraRepository;
 import org.springframework.data.cassandra.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 /**
  * FollowersByUser 엔티티를 위한 Cassandra Repository
  * 
- * 주요 기능:
- * - 팔로우 관계 생성/삭제
- * - 특정 사용자의 모든 팔로워 조회 (Fan-out on Write에서 핵심)
- * - 팔로우 관계 존재 여부 확인
- * - 팔로워 수 카운팅
+ * API 지원 기능:
+ * - POST /follow/{userId}: 팔로우 생성
+ * - DELETE /follow/{userId}: 팔로우 삭제
+ * - Fan-out on Write 지원
  */
 @Repository
 public interface FollowRepository extends CassandraRepository<FollowersByUser, FollowersByUserKey> {
 
     /**
-     * 특정 사용자의 모든 팔로워 조회
-     * Fan-out on Write에서 핵심적으로 사용되는 쿼리
-     * @param followedUserId 팔로우 당하는 사용자 ID
-     * @return 팔로워 목록
-     */
-    @Query("SELECT * FROM followers_by_user WHERE followed_user_id = ?0")
-    List<FollowersByUser> findByKeyFollowedUserId(UUID followedUserId);
-
-    /**
-     * 특정 사용자의 팔로워 ID 목록만 조회 (성능 최적화)
+     * 특정 사용자의 모든 팔로워 ID 조회
+     * Fan-out on Write에서 핵심적으로 사용
      * @param followedUserId 팔로우 당하는 사용자 ID
      * @return 팔로워 ID 목록
      */
@@ -39,6 +29,7 @@ public interface FollowRepository extends CassandraRepository<FollowersByUser, F
 
     /**
      * 팔로우 관계 존재 여부 확인
+     * 중복 팔로우 방지용
      * @param followedUserId 팔로우 당하는 사용자 ID
      * @param followerId 팔로우 하는 사용자 ID
      * @return 팔로우 관계 존재 여부
@@ -47,22 +38,13 @@ public interface FollowRepository extends CassandraRepository<FollowersByUser, F
     boolean existsByKeyFollowedUserIdAndKeyFollowerId(UUID followedUserId, UUID followerId);
 
     /**
-     * 팔로워 수 카운팅
-     * 인플루언서 판단 기준으로 사용
+     * 팔로워 수 조회
+     * 인플루언서 판단 기준
      * @param followedUserId 팔로우 당하는 사용자 ID
      * @return 팔로워 수
      */
     @Query("SELECT COUNT(*) FROM followers_by_user WHERE followed_user_id = ?0")
     long countByKeyFollowedUserId(UUID followedUserId);
-
-    /**
-     * 특정 기간 이후의 팔로워 조회
-     * @param followedUserId 팔로우 당하는 사용자 ID
-     * @param followedAt 기준 시간
-     * @return 해당 기간 이후 팔로워 목록
-     */
-    @Query("SELECT * FROM followers_by_user WHERE followed_user_id = ?0 AND followed_at >= ?1 ALLOW FILTERING")
-    List<FollowersByUser> findByKeyFollowedUserIdAndFollowedAtAfter(UUID followedUserId, LocalDateTime followedAt);
 
     /**
      * 팔로우 관계 삭제 (언팔로우)
@@ -71,20 +53,4 @@ public interface FollowRepository extends CassandraRepository<FollowersByUser, F
      */
     @Query("DELETE FROM followers_by_user WHERE followed_user_id = ?0 AND follower_id = ?1")
     void deleteByKeyFollowedUserIdAndKeyFollowerId(UUID followedUserId, UUID followerId);
-
-    /**
-     * 특정 사용자의 모든 팔로워 관계 삭제
-     * (계정 삭제 시 사용)
-     * @param followedUserId 팔로우 당하는 사용자 ID
-     */
-    @Query("DELETE FROM followers_by_user WHERE followed_user_id = ?0")
-    void deleteByKeyFollowedUserId(UUID followedUserId);
-
-    /**
-     * 팔로워 수 기준으로 인플루언서 후보 조회
-     * @param minFollowerCount 최소 팔로워 수
-     * @return 인플루언서 후보 사용자 ID 목록
-     */
-    @Query("SELECT followed_user_id FROM followers_by_user GROUP BY followed_user_id HAVING COUNT(*) >= ?0 ALLOW FILTERING")
-    List<UUID> findUsersWithMinFollowers(long minFollowerCount);
 } 

--- a/src/main/java/com/example/demo/domain/follow/FollowersByUser.java
+++ b/src/main/java/com/example/demo/domain/follow/FollowersByUser.java
@@ -1,13 +1,12 @@
-// src/main/java/com/example/demo/domain/follow/FollowersByUser.java
+
 package com.example.demo.domain.follow;
 
-import com.example.demo.domain.BaseEntity;
+import com.example.demo.domain.CassandraBaseEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.cassandra.core.mapping.PrimaryKey;
 import org.springframework.data.cassandra.core.mapping.Table;
-import org.springframework.data.cassandra.core.mapping.Column;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -16,7 +15,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
-public class FollowersByUser extends BaseEntity {
+public class FollowersByUser extends CassandraBaseEntity {
 
     /**
      * 복합 Primary Key
@@ -26,21 +25,20 @@ public class FollowersByUser extends BaseEntity {
     private FollowersByUserKey key;
 
     /**
-     * 팔로우 시작 시간
-     * - 언제부터 팔로우 관계가 시작되었는지 기록
-     * - 팔로우 순서나 통계 분석에 활용 가능
-     */
-    @Column("followed_at")
-    private LocalDateTime followedAt;
-
-    /**
      * 팔로우 관계 생성 생성자
      * @param followedUserId 팔로우 당하는 사용자 ID  
      * @param followerId 팔로우 하는 사용자 ID
+     * @param createdAt 팔로우 시작 시간
      */
-    public FollowersByUser(UUID followedUserId, UUID followerId) {
+    public FollowersByUser(UUID followedUserId, UUID followerId, LocalDateTime createdAt) {
         this.key = new FollowersByUserKey(followedUserId, followerId);
-        this.followedAt = LocalDateTime.now();
-        // createdAt, modifiedAt은 BaseEntity에서 자동 관리
+        this.setCreatedAt(createdAt);
+    }
+
+    /**
+     * 팔로우 시작 시간 조회 (createdAt 활용)
+     */
+    public LocalDateTime getFollowedAt() {
+        return this.getCreatedAt();
     }
 }

--- a/src/main/java/com/example/demo/domain/test/TestController.java
+++ b/src/main/java/com/example/demo/domain/test/TestController.java
@@ -12,7 +12,7 @@ public class TestController {
     private final TestService testService;
 
     @GetMapping("/v1/test/{userId}")
-    public TestEntity request(@PathVariable Long userId) {
+    public TestEntityMySql request(@PathVariable Long userId) {
         return testService.orderItem(userId);
     }
 }

--- a/src/main/java/com/example/demo/domain/test/TestEntityMySql.java
+++ b/src/main/java/com/example/demo/domain/test/TestEntityMySql.java
@@ -1,13 +1,13 @@
 package com.example.demo.domain.test;
 
-import com.example.demo.domain.BaseEntity;
+import com.example.demo.domain.MySqlBaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
-public class TestEntity extends BaseEntity {
+public class TestEntityMySql extends MySqlBaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/demo/domain/test/TestRepository.java
+++ b/src/main/java/com/example/demo/domain/test/TestRepository.java
@@ -2,6 +2,6 @@ package com.example.demo.domain.test;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TestRepository extends JpaRepository<TestEntity, Long> {
+public interface TestRepository extends JpaRepository<TestEntityMySql, Long> {
 
 }

--- a/src/main/java/com/example/demo/domain/test/TestService.java
+++ b/src/main/java/com/example/demo/domain/test/TestService.java
@@ -9,12 +9,12 @@ public class TestService {
 
     private final TestRepository testRepository;
 
-    public TestEntity orderItem(Long userId) {
+    public TestEntityMySql orderItem(Long userId) {
         if (userId == 0L) {
             throw new RuntimeException("예외 발생!");
         }
 
-        TestEntity testEntity = testRepository.findById(userId).orElse(null);
+        TestEntityMySql testEntity = testRepository.findById(userId).orElse(null);
         sleep(1000);
         return testEntity;
     }

--- a/src/main/java/com/example/demo/domain/timeline/UserTimeline.java
+++ b/src/main/java/com/example/demo/domain/timeline/UserTimeline.java
@@ -1,7 +1,6 @@
-// src/main/java/com/example/demo/domain/timeline/UserTimeline.java
 package com.example.demo.domain.timeline;
 
-import com.example.demo.domain.BaseEntity;
+import com.example.demo.domain.CassandraBaseEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -19,7 +18,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
-public class UserTimeline extends BaseEntity {
+public class UserTimeline extends CassandraBaseEntity {
 
     /**
      * 복합 Primary Key
@@ -52,10 +51,10 @@ public class UserTimeline extends BaseEntity {
      * @param authorId 트윗 작성자 ID
      * @param tweetText 트윗 내용
      */
-    public UserTimeline(UUID followerId, UUID tweetId, UUID authorId, String tweetText) {
-        this.key = new UserTimelineKey(followerId, LocalDateTime.now(), tweetId);
+    public UserTimeline(UUID followerId, UUID tweetId, UUID authorId, String tweetText, LocalDateTime createdAt) {
+        this.key = new UserTimelineKey(followerId, createdAt, tweetId);
         this.authorId = authorId;
         this.tweetText = tweetText;
-        // createdAt, modifiedAt은 BaseEntity에서 자동 관리
+        this.setCreatedAt(createdAt);
     }
 }

--- a/src/main/java/com/example/demo/domain/timeline/UserTimelineRepository.java
+++ b/src/main/java/com/example/demo/domain/timeline/UserTimelineRepository.java
@@ -20,41 +20,18 @@ public interface UserTimelineRepository extends CassandraRepository<UserTimeline
 
     /**
      * 특정 사용자의 최신 타임라인 조회
-     * GET /timeline?last={timestamp} API 지원
      * @param followerId 타임라인 소유자 ID
-     * @param limit 조회할 트윗 수 (기본 20개)
-     * @return 시간순 정렬된 타임라인 목록
+     * @return 최신순 타임라인 목록 (최대 20개)
      */
-    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 ORDER BY created_at DESC LIMIT ?1")
-    List<UserTimeline> findByKeyFollowerIdOrderByKeyCreatedAtDesc(UUID followerId, int limit);
+    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 LIMIT 20")
+    List<UserTimeline> findLatestTimeline(UUID followerId);
 
     /**
-     * 커서 기반 페이지네이션 - 특정 시간 이전 트윗 조회
-     * GET /timeline?last={timestamp} API의 다음 페이지 조회
+     * 커서 기반 페이지네이션
      * @param followerId 타임라인 소유자 ID
-     * @param cursor 기준 시간 (이 시간 이전 트윗들 조회)
-     * @param limit 조회할 트윗 수
+     * @param cursor 기준 시간
      * @return 타임라인 목록
      */
-    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 AND created_at < ?1 ORDER BY created_at DESC LIMIT ?2")
-    List<UserTimeline> findByKeyFollowerIdAndKeyCreatedAtBefore(UUID followerId, LocalDateTime cursor, int limit);
-
-    /**
-     * 특정 트윗을 타임라인에서 제거
-     * 트윗 삭제 시 모든 타임라인에서 제거용
-     * @param followerId 타임라인 소유자 ID
-     * @param createdAt 생성 시간
-     * @param tweetId 트윗 ID
-     */
-    @Query("DELETE FROM user_timeline WHERE follower_id = ?0 AND created_at = ?1 AND tweet_id = ?2")
-    void deleteByKeyFollowerIdAndKeyCreatedAtAndKeyTweetId(UUID followerId, LocalDateTime createdAt, UUID tweetId);
-
-    /**
-     * 배치 삽입을 위한 여러 타임라인 엔트리 저장
-     * Fan-out on Write 시 성능 최적화
-     * @param timelines 저장할 타임라인 목록
-     */
-    default void saveAllTimelines(List<UserTimeline> timelines) {
-        saveAll(timelines);
-    }
+    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 AND created_at < ?1 LIMIT 20")
+    List<UserTimeline> findTimelineWithCursor(UUID followerId, LocalDateTime cursor);
 } 

--- a/src/main/java/com/example/demo/domain/timeline/UserTimelineRepository.java
+++ b/src/main/java/com/example/demo/domain/timeline/UserTimelineRepository.java
@@ -11,27 +11,26 @@ import java.util.UUID;
 /**
  * UserTimeline 엔티티를 위한 Cassandra Repository
  * 
- * 주요 기능:
- * - Fan-out on Write 결과물 저장/조회
- * - 시간순 타임라인 조회 (최신순)
- * - 커서 기반 페이지네이션 지원
- * - 특정 트윗 타임라인에서 제거
+ * API 지원 기능:
+ * - GET /timeline: 타임라인 조회 (커서 기반 페이지네이션)
+ * - Fan-out on Write 전략 지원
  */
 @Repository
 public interface UserTimelineRepository extends CassandraRepository<UserTimeline, UserTimelineKey> {
 
     /**
      * 특정 사용자의 최신 타임라인 조회
-     * 시간순 내림차순으로 정렬되어 있음 (Cassandra 클러스터링 키 활용)
+     * GET /timeline?last={timestamp} API 지원
      * @param followerId 타임라인 소유자 ID
-     * @param limit 조회할 트윗 수
-     * @return 타임라인 목록
+     * @param limit 조회할 트윗 수 (기본 20개)
+     * @return 시간순 정렬된 타임라인 목록
      */
     @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 ORDER BY created_at DESC LIMIT ?1")
     List<UserTimeline> findByKeyFollowerIdOrderByKeyCreatedAtDesc(UUID followerId, int limit);
 
     /**
      * 커서 기반 페이지네이션 - 특정 시간 이전 트윗 조회
+     * GET /timeline?last={timestamp} API의 다음 페이지 조회
      * @param followerId 타임라인 소유자 ID
      * @param cursor 기준 시간 (이 시간 이전 트윗들 조회)
      * @param limit 조회할 트윗 수
@@ -41,29 +40,8 @@ public interface UserTimelineRepository extends CassandraRepository<UserTimeline
     List<UserTimeline> findByKeyFollowerIdAndKeyCreatedAtBefore(UUID followerId, LocalDateTime cursor, int limit);
 
     /**
-     * 특정 시간 이후의 타임라인 조회
-     * (실시간 업데이트 시 사용)
-     * @param followerId 타임라인 소유자 ID
-     * @param cursor 기준 시간 (이 시간 이후 트윗들 조회)
-     * @param limit 조회할 트윗 수
-     * @return 타임라인 목록
-     */
-    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 AND created_at > ?1 ORDER BY created_at DESC LIMIT ?2")
-    List<UserTimeline> findByKeyFollowerIdAndKeyCreatedAtAfter(UUID followerId, LocalDateTime cursor, int limit);
-
-    /**
-     * 특정 작성자의 트윗들을 특정 사용자 타임라인에서 조회
-     * (언팔로우 시 제거할 트윗들 찾기)
-     * @param followerId 타임라인 소유자 ID
-     * @param authorId 트윗 작성자 ID
-     * @return 해당 작성자의 타임라인 목록
-     */
-    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 AND author_id = ?1 ALLOW FILTERING")
-    List<UserTimeline> findByKeyFollowerIdAndAuthorId(UUID followerId, UUID authorId);
-
-    /**
      * 특정 트윗을 타임라인에서 제거
-     * (트윗 삭제 시 모든 타임라인에서 제거)
+     * 트윗 삭제 시 모든 타임라인에서 제거용
      * @param followerId 타임라인 소유자 ID
      * @param createdAt 생성 시간
      * @param tweetId 트윗 ID
@@ -72,46 +50,11 @@ public interface UserTimelineRepository extends CassandraRepository<UserTimeline
     void deleteByKeyFollowerIdAndKeyCreatedAtAndKeyTweetId(UUID followerId, LocalDateTime createdAt, UUID tweetId);
 
     /**
-     * 특정 사용자의 전체 타임라인 삭제
-     * (계정 삭제 시 사용)
-     * @param followerId 타임라인 소유자 ID
-     */
-    @Query("DELETE FROM user_timeline WHERE follower_id = ?0")
-    void deleteByKeyFollowerId(UUID followerId);
-
-    /**
-     * 특정 작성자의 모든 트윗을 특정 사용자 타임라인에서 제거
-     * (언팔로우 시 사용)
-     * @param followerId 타임라인 소유자 ID
-     * @param authorId 제거할 트윗 작성자 ID
-     */
-    @Query("DELETE FROM user_timeline WHERE follower_id = ?0 AND author_id = ?1")
-    void deleteByKeyFollowerIdAndAuthorId(UUID followerId, UUID authorId);
-
-    /**
-     * 특정 사용자 타임라인의 트윗 수 조회
-     * @param followerId 타임라인 소유자 ID
-     * @return 타임라인의 트윗 수
-     */
-    @Query("SELECT COUNT(*) FROM user_timeline WHERE follower_id = ?0")
-    long countByKeyFollowerId(UUID followerId);
-
-    /**
      * 배치 삽입을 위한 여러 타임라인 엔트리 저장
-     * (Fan-out 시 성능 최적화)
+     * Fan-out on Write 시 성능 최적화
      * @param timelines 저장할 타임라인 목록
      */
     default void saveAllTimelines(List<UserTimeline> timelines) {
         saveAll(timelines);
     }
-
-    /**
-     * 특정 기간 동안의 타임라인 조회
-     * @param followerId 타임라인 소유자 ID
-     * @param startTime 시작 시간
-     * @param endTime 종료 시간
-     * @return 해당 기간의 타임라인 목록
-     */
-    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 AND created_at >= ?1 AND created_at <= ?2 ORDER BY created_at DESC")
-    List<UserTimeline> findByKeyFollowerIdAndKeyCreatedAtBetween(UUID followerId, LocalDateTime startTime, LocalDateTime endTime);
 } 

--- a/src/main/java/com/example/demo/domain/timeline/UserTimelineRepository.java
+++ b/src/main/java/com/example/demo/domain/timeline/UserTimelineRepository.java
@@ -1,0 +1,117 @@
+package com.example.demo.domain.timeline;
+
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * UserTimeline 엔티티를 위한 Cassandra Repository
+ * 
+ * 주요 기능:
+ * - Fan-out on Write 결과물 저장/조회
+ * - 시간순 타임라인 조회 (최신순)
+ * - 커서 기반 페이지네이션 지원
+ * - 특정 트윗 타임라인에서 제거
+ */
+@Repository
+public interface UserTimelineRepository extends CassandraRepository<UserTimeline, UserTimelineKey> {
+
+    /**
+     * 특정 사용자의 최신 타임라인 조회
+     * 시간순 내림차순으로 정렬되어 있음 (Cassandra 클러스터링 키 활용)
+     * @param followerId 타임라인 소유자 ID
+     * @param limit 조회할 트윗 수
+     * @return 타임라인 목록
+     */
+    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 ORDER BY created_at DESC LIMIT ?1")
+    List<UserTimeline> findByKeyFollowerIdOrderByKeyCreatedAtDesc(UUID followerId, int limit);
+
+    /**
+     * 커서 기반 페이지네이션 - 특정 시간 이전 트윗 조회
+     * @param followerId 타임라인 소유자 ID
+     * @param cursor 기준 시간 (이 시간 이전 트윗들 조회)
+     * @param limit 조회할 트윗 수
+     * @return 타임라인 목록
+     */
+    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 AND created_at < ?1 ORDER BY created_at DESC LIMIT ?2")
+    List<UserTimeline> findByKeyFollowerIdAndKeyCreatedAtBefore(UUID followerId, LocalDateTime cursor, int limit);
+
+    /**
+     * 특정 시간 이후의 타임라인 조회
+     * (실시간 업데이트 시 사용)
+     * @param followerId 타임라인 소유자 ID
+     * @param cursor 기준 시간 (이 시간 이후 트윗들 조회)
+     * @param limit 조회할 트윗 수
+     * @return 타임라인 목록
+     */
+    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 AND created_at > ?1 ORDER BY created_at DESC LIMIT ?2")
+    List<UserTimeline> findByKeyFollowerIdAndKeyCreatedAtAfter(UUID followerId, LocalDateTime cursor, int limit);
+
+    /**
+     * 특정 작성자의 트윗들을 특정 사용자 타임라인에서 조회
+     * (언팔로우 시 제거할 트윗들 찾기)
+     * @param followerId 타임라인 소유자 ID
+     * @param authorId 트윗 작성자 ID
+     * @return 해당 작성자의 타임라인 목록
+     */
+    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 AND author_id = ?1 ALLOW FILTERING")
+    List<UserTimeline> findByKeyFollowerIdAndAuthorId(UUID followerId, UUID authorId);
+
+    /**
+     * 특정 트윗을 타임라인에서 제거
+     * (트윗 삭제 시 모든 타임라인에서 제거)
+     * @param followerId 타임라인 소유자 ID
+     * @param createdAt 생성 시간
+     * @param tweetId 트윗 ID
+     */
+    @Query("DELETE FROM user_timeline WHERE follower_id = ?0 AND created_at = ?1 AND tweet_id = ?2")
+    void deleteByKeyFollowerIdAndKeyCreatedAtAndKeyTweetId(UUID followerId, LocalDateTime createdAt, UUID tweetId);
+
+    /**
+     * 특정 사용자의 전체 타임라인 삭제
+     * (계정 삭제 시 사용)
+     * @param followerId 타임라인 소유자 ID
+     */
+    @Query("DELETE FROM user_timeline WHERE follower_id = ?0")
+    void deleteByKeyFollowerId(UUID followerId);
+
+    /**
+     * 특정 작성자의 모든 트윗을 특정 사용자 타임라인에서 제거
+     * (언팔로우 시 사용)
+     * @param followerId 타임라인 소유자 ID
+     * @param authorId 제거할 트윗 작성자 ID
+     */
+    @Query("DELETE FROM user_timeline WHERE follower_id = ?0 AND author_id = ?1")
+    void deleteByKeyFollowerIdAndAuthorId(UUID followerId, UUID authorId);
+
+    /**
+     * 특정 사용자 타임라인의 트윗 수 조회
+     * @param followerId 타임라인 소유자 ID
+     * @return 타임라인의 트윗 수
+     */
+    @Query("SELECT COUNT(*) FROM user_timeline WHERE follower_id = ?0")
+    long countByKeyFollowerId(UUID followerId);
+
+    /**
+     * 배치 삽입을 위한 여러 타임라인 엔트리 저장
+     * (Fan-out 시 성능 최적화)
+     * @param timelines 저장할 타임라인 목록
+     */
+    default void saveAllTimelines(List<UserTimeline> timelines) {
+        saveAll(timelines);
+    }
+
+    /**
+     * 특정 기간 동안의 타임라인 조회
+     * @param followerId 타임라인 소유자 ID
+     * @param startTime 시작 시간
+     * @param endTime 종료 시간
+     * @return 해당 기간의 타임라인 목록
+     */
+    @Query("SELECT * FROM user_timeline WHERE follower_id = ?0 AND created_at >= ?1 AND created_at <= ?2 ORDER BY created_at DESC")
+    List<UserTimeline> findByKeyFollowerIdAndKeyCreatedAtBetween(UUID followerId, LocalDateTime startTime, LocalDateTime endTime);
+} 

--- a/src/main/java/com/example/demo/domain/tweet/Tweet.java
+++ b/src/main/java/com/example/demo/domain/tweet/Tweet.java
@@ -1,7 +1,6 @@
 package com.example.demo.domain.tweet;
 
-import com.example.demo.domain.BaseEntity;
-import lombok.AllArgsConstructor;
+import com.example.demo.domain.CassandraBaseEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,13 +8,14 @@ import org.springframework.data.cassandra.core.mapping.Column;
 import org.springframework.data.cassandra.core.mapping.PrimaryKey;
 import org.springframework.data.cassandra.core.mapping.Table;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Table("tweets")
 @Getter
 @Setter
 @NoArgsConstructor
-public class Tweet extends BaseEntity {
+public class Tweet extends CassandraBaseEntity {
 
     /**
      * 트윗 고유 식별자 (Primary Key)
@@ -47,9 +47,10 @@ public class Tweet extends BaseEntity {
      * @param userId 트윗 작성자 ID
      * @param tweetText 트윗 내용
      */
-    public Tweet(UUID userId, String tweetText) {
+    public Tweet(UUID userId, String tweetText, LocalDateTime createdAt) {
         this.tweetId = UUID.randomUUID(); // 자동으로 고유 ID 생성
         this.userId = userId;
         this.tweetText = tweetText;
+        this.setCreatedAt(createdAt);
     }
 }

--- a/src/main/java/com/example/demo/domain/tweet/TweetByUser.java
+++ b/src/main/java/com/example/demo/domain/tweet/TweetByUser.java
@@ -1,0 +1,64 @@
+package com.example.demo.domain.tweet;
+
+import com.example.demo.domain.CassandraBaseEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.PrimaryKey;
+import org.springframework.data.cassandra.core.mapping.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 사용자별 트윗 보조 테이블
+ * - 사용자 ID 기준으로 최신 트윗들을 빠르게 조회하기 위한 목적
+ * - 정렬/커서 기반 페이지네이션 등을 지원
+ * - tweets 테이블의 원본 일부를 비정규화하여 포함
+ */
+@Table("tweets_by_user")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TweetByUser extends CassandraBaseEntity {
+
+    /**
+     * 복합 키 (user_id, created_at, tweet_id)
+     */
+    @PrimaryKey
+    private TweetByUserKey key;
+
+    /**
+     * 트윗 본문
+     */
+    @Column("tweet_text")
+    private String tweetText;
+
+    /**
+     * 사용자별 트윗 객체 생성자
+     * @param userId 작성자 ID
+     * @param tweetId 트윗 고유 ID
+     * @param tweetText 트윗 내용
+     * @param createdAt 생성 시간
+     */
+    @Builder
+    public TweetByUser(UUID userId, UUID tweetId, String tweetText, LocalDateTime createdAt) {
+        this.key = new TweetByUserKey(userId, createdAt, tweetId);
+        this.tweetText = tweetText;
+        this.setCreatedAt(createdAt);
+    }
+
+    /**
+     * 작성자 ID 조회 (키에서 가져옴)
+     * @return 작성자 ID, key가 null인 경우 예외 발생
+     * @throws IllegalStateException key가 초기화되지 않은 경우
+     */
+    public UUID getAuthorId() {
+        if (this.key == null) {
+            throw new IllegalStateException("TweetByUserKey가 초기화되지 않았습니다.");
+        }
+        return this.key.getUserId();
+    }
+}

--- a/src/main/java/com/example/demo/domain/tweet/TweetByUserKey.java
+++ b/src/main/java/com/example/demo/domain/tweet/TweetByUserKey.java
@@ -1,0 +1,47 @@
+package com.example.demo.domain.tweet;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.cassandra.core.cql.Ordering;
+import org.springframework.data.cassandra.core.cql.PrimaryKeyType;
+import org.springframework.data.cassandra.core.mapping.PrimaryKeyClass;
+import org.springframework.data.cassandra.core.mapping.PrimaryKeyColumn;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 사용자별 트윗 조회를 위한 복합 키
+ * - user_id를 파티션 키로 설정하여 한 유저의 트윗을 동일 노드에 저장
+ * - created_at DESC 정렬로 최신 트윗 우선 조회 가능
+ * - tweet_id는 동일 시간 충돌 방지 및 커서 페이징 용도
+ */
+@PrimaryKeyClass
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TweetByUserKey implements Serializable {
+
+    /**
+     * 트윗 작성자 ID (파티션 키)
+     */
+    @PrimaryKeyColumn(name = "user_id", type = PrimaryKeyType.PARTITIONED)
+    private UUID userId;
+
+    /**
+     * 트윗 작성 시각 (클러스터링 키, 내림차순 정렬)
+     */
+    @PrimaryKeyColumn(name = "created_at", type = PrimaryKeyType.CLUSTERED, ordering = Ordering.DESCENDING)
+    private LocalDateTime createdAt;
+
+    /**
+     * 트윗 고유 ID (클러스터링 키)
+     * - 같은 시각에 여러 트윗이 있을 경우 고유성 보장
+     */
+    @PrimaryKeyColumn(name = "tweet_id", type = PrimaryKeyType.CLUSTERED)
+    private UUID tweetId;
+}

--- a/src/main/java/com/example/demo/domain/tweet/TweetByUserRepository.java
+++ b/src/main/java/com/example/demo/domain/tweet/TweetByUserRepository.java
@@ -1,0 +1,33 @@
+package com.example.demo.domain.tweet;
+
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 사용자별 트윗 조회를 위한 Cassandra Repository
+ */
+@Repository
+public interface TweetByUserRepository extends CassandraRepository<TweetByUser, TweetByUserKey> {
+
+    /**
+     * 특정 사용자의 최신 트윗 조회
+     * @param userId 사용자 ID
+     * @return 최신순 트윗 목록 (최대 20개)
+     */
+    @Query("SELECT * FROM tweets_by_user WHERE user_id = ?0 LIMIT 20")
+    List<TweetByUser> findLatestTweets(UUID userId);
+
+    /**
+     * 커서 기반 페이지네이션
+     * @param userId 사용자 ID
+     * @param cursor 기준 시간
+     * @return 트윗 목록
+     */
+    @Query("SELECT * FROM tweets_by_user WHERE user_id = ?0 AND created_at < ?1 LIMIT 20")
+    List<TweetByUser> findTweetsWithCursor(UUID userId, LocalDateTime cursor);
+}

--- a/src/main/java/com/example/demo/domain/tweet/TweetRepository.java
+++ b/src/main/java/com/example/demo/domain/tweet/TweetRepository.java
@@ -1,65 +1,22 @@
 package com.example.demo.domain.tweet;
 
 import org.springframework.data.cassandra.repository.CassandraRepository;
-import org.springframework.data.cassandra.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 /**
  * Tweet 엔티티를 위한 Cassandra Repository
- * 
- * API 지원 기능:
- * - POST /tweets: 트윗 생성
- * - GET /tweets/{userId}: 사용자별 트윗 조회
+ * 트윗 CRUD 기본 기능 제공
  */
 @Repository
 public interface TweetRepository extends CassandraRepository<Tweet, UUID> {
 
     /**
-     * 트윗 ID로 개별 트윗 조회
-     * @param tweetId 트윗 고유 ID
-     * @return 트윗 정보
-     */
-    Optional<Tweet> findByTweetId(UUID tweetId);
-
-    /**
-     * 특정 사용자의 최신 트윗 조회
-     * GET /tweets/{userId} API 지원
-     * 참고: 성능 최적화를 위해 별도 테이블 설계 권장
-     * @param userId 사용자 ID
-     * @param limit 조회할 트윗 수
-     * @return 사용자의 트윗 목록
-     */
-    @Query("SELECT * FROM tweets WHERE user_id = ?0 ORDER BY created_at DESC LIMIT ?1 ALLOW FILTERING")
-    List<Tweet> findByUserIdOrderByCreatedAtDesc(UUID userId, int limit);
-
-    /**
-     * 커서 기반 사용자 트윗 조회
-     * GET /tweets/{userId}?last={timestamp} API 지원
-     * @param userId 사용자 ID
-     * @param cursor 기준 시간
-     * @param limit 조회할 트윗 수
-     * @return 사용자의 트윗 목록
-     */
-    @Query("SELECT * FROM tweets WHERE user_id = ?0 AND created_at < ?1 ORDER BY created_at DESC LIMIT ?2 ALLOW FILTERING")
-    List<Tweet> findByUserIdAndCreatedAtBefore(UUID userId, LocalDateTime cursor, int limit);
-
-    /**
-     * 트윗 삭제 (작성자 본인만 가능)
-     * @param tweetId 삭제할 트윗 ID
-     */
-    void deleteByTweetId(UUID tweetId);
-
-    /**
-     * 권한 검증용: 특정 사용자가 작성한 트윗인지 확인
+     * 트윗 작성자 검증 (권한 확인용)
      * @param tweetId 트윗 ID
      * @param userId 사용자 ID
      * @return 존재 여부
      */
-    @Query("SELECT COUNT(*) FROM tweets WHERE tweet_id = ?0 AND user_id = ?1")
     boolean existsByTweetIdAndUserId(UUID tweetId, UUID userId);
 } 

--- a/src/main/java/com/example/demo/domain/tweet/TweetRepository.java
+++ b/src/main/java/com/example/demo/domain/tweet/TweetRepository.java
@@ -1,0 +1,63 @@
+package com.example.demo.domain.tweet;
+
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Tweet 엔티티를 위한 Cassandra Repository
+ * 
+ * 주요 기능:
+ * - 트윗 원본 저장/조회/삭제
+ * - UUID 기반 직접 접근 (O(1) 성능)
+ * - 트윗 수정 및 메타데이터 업데이트
+ */
+@Repository
+public interface TweetRepository extends CassandraRepository<Tweet, UUID> {
+
+    /**
+     * 트윗 ID로 트윗 조회
+     * @param tweetId 트윗 고유 ID
+     * @return 트윗 정보 (Optional)
+     */
+    Optional<Tweet> findByTweetId(UUID tweetId);
+
+    /**
+     * 특정 사용자가 작성한 트윗 존재 여부 확인
+     * (권한 검증 시 사용)
+     * @param tweetId 트윗 ID
+     * @param userId 사용자 ID
+     * @return 존재 여부
+     */
+    @Query("SELECT COUNT(*) FROM tweets WHERE tweet_id = ?0 AND user_id = ?1")
+    boolean existsByTweetIdAndUserId(UUID tweetId, UUID userId);
+
+    /**
+     * 여러 트윗을 배치로 조회
+     * (타임라인 상세 정보 조회 시 사용)
+     * @param tweetIds 트윗 ID 목록
+     * @return 트윗 목록
+     */
+    @Query("SELECT * FROM tweets WHERE tweet_id IN ?0")
+    List<Tweet> findByTweetIdIn(List<UUID> tweetIds);
+
+    /**
+     * 트윗 텍스트 업데이트
+     * @param tweetId 트윗 ID
+     * @param tweetText 새로운 트윗 내용
+     * @param modifiedAt 수정 시간
+     */
+    @Query("UPDATE tweets SET tweet_text = ?1, modified_at = ?2 WHERE tweet_id = ?0")
+    void updateTweetText(UUID tweetId, String tweetText, LocalDateTime modifiedAt);
+
+    /**
+     * 트윗 삭제
+     * @param tweetId 삭제할 트윗 ID
+     */
+    void deleteByTweetId(UUID tweetId);
+} 


### PR DESCRIPTION
🗑️ 제거된 문제 메서드들
Critical 성능 문제 (전체 테이블 스캔)
FollowRepository.findUsersWithMinFollowers() - GROUP BY + HAVING + ALLOW FILTERING
CelebrityTweetRepository.findAllByKeyCreatedAtAfter() - 전체 테이블 스캔
CelebrityTweetRepository.getCelebrityTweetStats() - GROUP BY 집계

ALLOW FILTERING 남용
UserTimelineRepository.findByKeyFollowerIdAndAuthorId() - 파티션 내 스캔
CelebrityTweetRepository.findByKeyAuthorIdAndKeyTweetId() - 파티션 내 스캔
FollowRepository.findByKeyFollowedUserIdAndFollowedAtAfter() - 시간 필터링

