### PR TITLE
[FEAT] 레디스 도입 전과 후 비교 기능

### DIFF
--- a/src/main/java/com/example/demo/config/RedisConfig.java
+++ b/src/main/java/com/example/demo/config/RedisConfig.java
@@ -1,0 +1,74 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Redis 설정 클래스
+ * 
+ * 핵심 기능:
+ * - RedisTemplate 설정 (JSON 직렬화)
+ * - ZSetOperations Bean 제공 (타임라인용 SortedSet)
+ * - 타임라인 캐싱을 위한 Redis 연동
+ */
+@Configuration
+public class RedisConfig {
+
+    /**
+     * LocalDateTime 지원 ObjectMapper
+     * 
+     * Java 8 시간 타입(LocalDateTime) 직렬화를 위한 설정
+     */
+    @Bean
+    public ObjectMapper redisObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+
+    /**
+     * RedisTemplate 설정
+     * 
+     * 설정 내용:
+     * - Key: String 직렬화
+     * - Value: JSON 직렬화 (LocalDateTime 지원)
+     * - Hash Key/Value: String/JSON 직렬화
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory, ObjectMapper redisObjectMapper) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        
+        // Key 직렬화: String
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        
+        // Value 직렬화: JSON (LocalDateTime 지원)
+        GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+        template.setValueSerializer(jsonSerializer);
+        template.setHashValueSerializer(jsonSerializer);
+        
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    /**
+     * ZSetOperations Bean
+     * 
+     * 타임라인용 Redis SortedSet 연산을 위한 Bean
+     * Score: 트윗 생성 시간 (timestamp)
+     * Value: 트윗 정보 (JSON)
+     */
+    @Bean
+    public ZSetOperations<String, Object> zSetOperations(RedisTemplate<String, Object> redisTemplate) {
+        return redisTemplate.opsForZSet();
+    }
+}

--- a/src/main/java/com/example/demo/domain2/follow_r/repository/RdbFollowRepository.java
+++ b/src/main/java/com/example/demo/domain2/follow_r/repository/RdbFollowRepository.java
@@ -17,12 +17,22 @@ import java.util.UUID;
 public interface RdbFollowRepository extends JpaRepository<Follow, Long> {
 
     /**
-     * 특정 사용자의 팔로워 ID 목록 조회
+     * 특정 사용자의 팔로워 ID 목록 조회 (네이티브 쿼리 사용)
+     * UUID VARCHAR(36) 변경으로 직접 문자열 비교 사용
+     * 
+     * @param userId 사용자 ID (하이픈 포함된 형식)
+     * @return 팔로워 ID 목록
+     */
+    @Query(value = "SELECT follower_id FROM follows WHERE user_id = ?1", nativeQuery = true)
+    List<String> findFollowerIdsAsString(@Param("userId") String userId);
+    
+    /**
+     * 특정 사용자의 팔로워 ID 목록 조회 (기존 JPQL - 백업용)
      * 
      * @param userId 사용자 ID
      * @return 팔로워 ID 목록
      */
-    @Query("SELECT f.followerId FROM Follow f WHERE f.userId = :userId")
+    @Query("SELECT f.followerId FROM com.example.demo.domain2.follow_r.entity.Follow f WHERE f.userId = :userId")
     List<UUID> findFollowerIds(@Param("userId") UUID userId);
 
     /**
@@ -31,7 +41,7 @@ public interface RdbFollowRepository extends JpaRepository<Follow, Long> {
      * @param followerId 팔로워 ID
      * @return 팔로우하는 사용자 ID 목록
      */
-    @Query("SELECT f.userId FROM Follow f WHERE f.followerId = :followerId")
+    @Query("SELECT f.userId FROM com.example.demo.domain2.follow_r.entity.Follow f WHERE f.followerId = :followerId")
     List<UUID> findFollowingIds(@Param("followerId") UUID followerId);
 
     /**

--- a/src/main/java/com/example/demo/domain2/tweet_r/service/RdbTweetService.java
+++ b/src/main/java/com/example/demo/domain2/tweet_r/service/RdbTweetService.java
@@ -51,7 +51,6 @@ public class RdbTweetService {
      * 1. 원본 트윗은 authorID 기준 샤딩
      * 2. 팔로워들의 타임라인은 followerID 기준 샤딩
      */
-    @Transactional
     public TweetResponse createTweet(UUID userId, CreateTweetRequest request) {
         if (userId == null) {
             throw new IllegalArgumentException("사용자 ID는 필수입니다");
@@ -60,19 +59,20 @@ public class RdbTweetService {
         UUID tweetId = UUIDUtil.generate();
         LocalDateTime now = LocalDateTime.now();
 
-        // 1. 원본 트윗 저장 (Controller에서 이미 샤드 설정됨)
-        saveTweetWithoutSharding(userId, tweetId, request.getContent(), now);
-
-        // 2. 사용자별 트윗 저장 (Controller에서 이미 샤드 설정됨)
-        saveTweetByUserWithoutSharding(userId, tweetId, request.getContent(), now);
-
-        // 3. Fan-out 시도 (팔로워 타임라인에 복사)
         try {
+            // 1. 원본 트윗 저장 (트랜잭션 적용, 샤드 분리)
+            saveTweetWithProperSharding(userId, tweetId, request.getContent(), now);
+
+            // 2. Fan-out 시도 (팔로워 타임라인에 복사)
             fanOutToFollowers(userId, tweetId, request.getContent(), now);
+            
         } catch (Exception e) {
-            log.error("Fan-out 실패 - userId: {}, tweetId: {}, error: {}", 
+            log.error("트윗 생성 실패 - userId: {}, tweetId: {}, error: {}", 
                     userId, tweetId, e.getMessage(), e);
-            // 원본 트윗은 저장되었으므로 실패해도 계속 진행
+            throw new RuntimeException("트윗 생성에 실패했습니다: " + e.getMessage(), e);
+        } finally {
+            // 샤드 정리
+            DataSourceConfig.clearShard();
         }
 
         log.info("RDB 트윗 생성 완료 (샤딩 적용) - userId: {}, tweetId: {}", userId, tweetId);
@@ -86,6 +86,37 @@ public class RdbTweetService {
                 .build();
         
         return TweetResponse.of(tweet);
+    }
+
+    /**
+     * 원본 트윗과 사용자별 트윗을 적절한 샤드에 트랜잭션으로 저장
+     */
+    private void saveTweetWithProperSharding(UUID userId, UUID tweetId, String content, LocalDateTime createdAt) {
+        // Controller에서 설정된 샤드를 무시하고 새로 설정
+        String tweetDataShardKey = ShardUtil.selectTweetDataShardKeyByUserId(userId);
+        log.info("=== 트윗 저장 샤드 설정 === userId: {}, 샤드: {}", userId, tweetDataShardKey);
+        
+        DataSourceConfig.setShard(tweetDataShardKey);
+        
+        try {
+            saveTweetWithTransaction(userId, tweetId, content, createdAt);
+            log.info("트윗 저장 완료 - userId: {}, tweetId: {}, 샤드: {}", userId, tweetId, tweetDataShardKey);
+        } catch (Exception e) {
+            log.error("트윗 저장 실패 - userId: {}, 샤드: {}, error: {}", userId, tweetDataShardKey, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * 원본 트윗과 사용자별 트윗을 트랜잭션으로 저장 (샤드는 이미 설정됨)
+     */
+    @Transactional
+    private void saveTweetWithTransaction(UUID userId, UUID tweetId, String content, LocalDateTime createdAt) {
+        // 원본 트윗 저장
+        saveTweetWithoutSharding(userId, tweetId, content, createdAt);
+        
+        // 사용자별 트윗 저장
+        saveTweetByUserWithoutSharding(userId, tweetId, content, createdAt);
     }
 
     /**
@@ -128,12 +159,17 @@ public class RdbTweetService {
      * 팔로워들의 타임라인에 새 트윗 복사 (Fan-out-on-write)
      */
     private void fanOutToFollowers(UUID authorId, UUID tweetId, String tweetText, LocalDateTime createdAt) {
+        log.info("=== Fan-out 디버깅 시작 === authorId: {}, tweetId: {}", authorId, tweetId);
+        
         try {
             // 1. 팔로워 목록 조회 (authorID 기준 샤딩 - shard0)
+            log.info("팔로워 조회 시작 - authorId: {}", authorId);
             List<UUID> followerIds = getFollowersWithSharding(authorId);
+            log.info("팔로워 조회 결과 - authorId: {}, 팔로워 수: {}, 팔로워 목록: {}", 
+                    authorId, followerIds.size(), followerIds);
 
             if (followerIds.isEmpty()) {
-                log.debug("팔로워 없음 - authorId: {}", authorId);
+                log.warn("팔로워 없음 - authorId: {}", authorId);
                 return;
             }
 
@@ -141,25 +177,60 @@ public class RdbTweetService {
 
             // 2. 각 팔로워의 타임라인에 트윗 추가 (followerID 기준 샤딩)
             int successCount = 0;
+            int failureCount = 0;
+            
             for (UUID followerId : followerIds) {
                 try {
-                    saveTimelineWithSharding(followerId, tweetId, authorId, tweetText, createdAt);
-                    successCount++;
+                    log.debug("개별 팔로워 Fan-out 시작 - followerId: {}, tweetId: {}", followerId, tweetId);
+                    
+                    // 재시도 로직 추가 (최대 3회)
+                    boolean saved = false;
+                    int retryCount = 0;
+                    Exception lastException = null;
+                    
+                    while (!saved && retryCount < 3) {
+                        try {
+                            saveTimelineWithSharding(followerId, tweetId, authorId, tweetText, createdAt);
+                            saved = true;
+                            successCount++;
+                            log.debug("개별 팔로워 Fan-out 성공 - followerId: {}, tweetId: {}, 시도: {}", 
+                                    followerId, tweetId, retryCount + 1);
+                        } catch (Exception e) {
+                            lastException = e;
+                            retryCount++;
+                            log.warn("개별 팔로워 Fan-out 재시도 - followerId: {}, 시도: {}, 오류: {}", 
+                                    followerId, retryCount, e.getMessage());
+                            
+                            if (retryCount < 3) {
+                                Thread.sleep(100); // 100ms 대기 후 재시도
+                            }
+                        }
+                    }
+                    
+                    if (!saved) {
+                        failureCount++;
+                        log.error("개별 팔로워 Fan-out 최종 실패 - followerId: {}, tweetId: {}, 최종 오류: {}", 
+                                followerId, tweetId, lastException.getMessage(), lastException);
+                    }
+                    
                 } catch (Exception e) {
-                    log.error("개별 팔로워 Fan-out 실패 - followerId: {}, tweetId: {}, error: {}", 
-                            followerId, tweetId, e.getMessage());
-                    // 개별 실패해도 다른 팔로워들은 계속 처리
+                    failureCount++;
+                    log.error("개별 팔로워 Fan-out 처리 중 예외 - followerId: {}, tweetId: {}, error: {}", 
+                            followerId, tweetId, e.getMessage(), e);
                 }
             }
             
-            log.info("Fan-out 완료 - authorId: {}, 전체: {}, 성공: {}, 실패: {}", 
-                    authorId, followerIds.size(), successCount, followerIds.size() - successCount);
+            log.info("Fan-out 완료 - authorId: {}, 전체: {}, 성공: {}, 실패: {}, 성공률: {:.2f}%", 
+                    authorId, followerIds.size(), successCount, failureCount, 
+                    (double) successCount / followerIds.size() * 100);
                     
         } catch (Exception e) {
             log.error("Fan-out 전체 실패 - authorId: {}, tweetId: {}, error: {}", 
-                    authorId, tweetId, e.getMessage());
+                    authorId, tweetId, e.getMessage(), e);
             // Fan-out 실패해도 원본 트윗은 유지
         }
+        
+        log.info("=== Fan-out 디버깅 종료 === authorId: {}, tweetId: {}", authorId, tweetId);
     }
 
     /**
@@ -169,20 +240,43 @@ public class RdbTweetService {
         String shardKey = ShardUtil.selectUserDataShardKey(); // 항상 shard0
         String currentShard = DataSourceConfig.getShard();
         
+        log.info("=== 팔로워 조회 샤드 변경 === currentShard: {}, targetShard: {}", currentShard, shardKey);
+        
         try {
             DataSourceConfig.setShard(shardKey);
-            List<UUID> followers = followRepository.findFollowerIds(authorId);
-            log.debug("팔로워 조회 완료 - authorId: {}, 팔로워 수: {}", authorId, followers.size());
+            String actualShard = DataSourceConfig.getShard();
+            log.info("샤드 설정 후 확인 - actualShard: {}", actualShard);
+            
+            // UUID VARCHAR(36) 변경으로 수정된 네이티브 쿼리 사용
+            List<String> followerIdStrings = followRepository.findFollowerIdsAsString(authorId.toString());
+            List<UUID> followers = followerIdStrings.stream()
+                    .map(UUID::fromString)
+                    .toList();
+            
+            log.info("팔로워 조회 완료 - authorId: {}, 팔로워 수: {}, 실제 사용된 샤드: {}", 
+                    authorId, followers.size(), actualShard);
+            
+            // 실제 SQL이 어떤 샤드로 갔는지 확인하기 위해 로그 추가
+            if (followers.isEmpty()) {
+                log.warn("!!!주의!!! 팔로워가 0명으로 조회됨 - 샤드 문제일 가능성 있음");
+                
+                // 디버깅을 위해 JPQL 메서드도 시도해보기
+                List<UUID> jpqlFollowers = followRepository.findFollowerIds(authorId);
+                log.info("JPQL 방식 팔로워 조회 결과: {}", jpqlFollowers.size());
+            }
+            
             return followers;
         } catch (Exception e) {
-            log.error("팔로워 조회 실패 - authorId: {}, error: {}", authorId, e.getMessage());
+            log.error("팔로워 조회 실패 - authorId: {}, error: {}", authorId, e.getMessage(), e);
             return new ArrayList<>(); // 빈 리스트 반환으로 안전하게 처리
         } finally {
             // 이전 샤드로 복원
             if (currentShard != null) {
                 DataSourceConfig.setShard(currentShard);
+                log.info("샤드 복원 완료 - restored to: {}", currentShard);
             } else {
                 DataSourceConfig.clearShard();
+                log.info("샤드 정리 완료");
             }
         }
     }
@@ -195,8 +289,12 @@ public class RdbTweetService {
         String shardKey = ShardUtil.selectTweetDataShardKeyByUserId(followerId);
         String currentShard = DataSourceConfig.getShard();
         
+        log.info("타임라인 저장 시작 - followerId: {}, shardKey: {}, currentShard: {}", 
+                followerId, shardKey, currentShard);
+        
         try {
             DataSourceConfig.setShard(shardKey);
+            log.info("샤드 설정 완료 - new shard: {}", shardKey);
             
             UserTimeline timeline = UserTimeline.builder()
                     .followerId(followerId)
@@ -206,20 +304,32 @@ public class RdbTweetService {
                     .createdAt(createdAt)
                     .build();
             
-            userTimelineRepository.save(timeline);
+            log.info("UserTimeline 엔티티 생성 완료 - {}", timeline);
             
-            log.debug("타임라인 저장 완료 - shard: {}, followerId: {}, tweetId: {}", 
-                    shardKey, followerId, tweetId);
+            UserTimeline savedTimeline = userTimelineRepository.save(timeline);
+            log.info("타임라인 저장 성공 - savedId: {}, shard: {}, followerId: {}, tweetId: {}", 
+                    savedTimeline.getId(), shardKey, followerId, tweetId);
+            
+            // 저장 검증
+            try {
+                long count = userTimelineRepository.count();
+                log.info("현재 shard {} 의 user_timelines 총 개수: {}", shardKey, count);
+            } catch (Exception countException) {
+                log.warn("저장 후 개수 확인 실패: {}", countException.getMessage());
+            }
+            
         } catch (Exception e) {
             log.error("타임라인 저장 실패 - shard: {}, followerId: {}, tweetId: {}, error: {}", 
-                    shardKey, followerId, tweetId, e.getMessage());
+                    shardKey, followerId, tweetId, e.getMessage(), e);
             // Fan-out 실패는 원본 트윗에 영향주지 않음
         } finally {
             // 이전 샤드로 복원
             if (currentShard != null) {
                 DataSourceConfig.setShard(currentShard);
+                log.info("샤드 복원 완료 - restored to: {}", currentShard);
             } else {
                 DataSourceConfig.clearShard();
+                log.info("샤드 정리 완료");
             }
         }
     }
@@ -231,8 +341,14 @@ public class RdbTweetService {
         // 크기 제한 (DoS 방지)
         size = Math.min(size, 50);
         
-        List<TweetByUser> tweets;
-            
+        // 트윗 데이터 조회용 샤드 설정
+        String tweetDataShardKey = ShardUtil.selectTweetDataShardKeyByUserId(userId);
+        log.info("=== 사용자 트윗 조회 샤드 설정 === userId: {}, 샤드: {}", userId, tweetDataShardKey);
+        DataSourceConfig.setShard(tweetDataShardKey);
+        
+        try {
+            List<TweetByUser> tweets;
+                
             if (lastTimestamp == null) {
                 tweets = tweetByUserRepository.findLatestTweets(userId)
                     .stream()
@@ -254,10 +370,13 @@ public class RdbTweetService {
                 ))
                 .collect(Collectors.toList());
             
-        LocalDateTime nextCursor = tweets.isEmpty() ? null 
-            : tweets.get(tweets.size() - 1).getKey().getCreatedAt();
-            
-        return new TweetListResponse(tweetResponses, nextCursor, tweets.size() == size);
+            LocalDateTime nextCursor = tweets.isEmpty() ? null 
+                : tweets.get(tweets.size() - 1).getKey().getCreatedAt();
+                
+            return new TweetListResponse(tweetResponses, nextCursor, tweets.size() == size);
+        } finally {
+            DataSourceConfig.clearShard();
+        }
     }
 
     /**
@@ -267,7 +386,13 @@ public class RdbTweetService {
         // 크기 제한 (DoS 방지)
         size = Math.min(size, 50);
         
-        List<UserTimeline> timeline;
+        // 타임라인 데이터 조회용 샤드 설정 
+        String tweetDataShardKey = ShardUtil.selectTweetDataShardKeyByUserId(followerId);
+        log.info("=== 타임라인 조회 샤드 설정 === followerId: {}, 샤드: {}", followerId, tweetDataShardKey);
+        DataSourceConfig.setShard(tweetDataShardKey);
+        
+        try {
+            List<UserTimeline> timeline;
             
             if (lastTimestamp == null) {
                 timeline = userTimelineRepository.findLatestTimeline(followerId)
@@ -290,9 +415,12 @@ public class RdbTweetService {
                 ))
                 .collect(Collectors.toList());
             
-        LocalDateTime nextCursor = timeline.isEmpty() ? null 
-            : timeline.get(timeline.size() - 1).getCreatedAt();
-            
-        return new TweetListResponse(tweetResponses, nextCursor, timeline.size() == size);
+            LocalDateTime nextCursor = timeline.isEmpty() ? null 
+                : timeline.get(timeline.size() - 1).getCreatedAt();
+                
+            return new TweetListResponse(tweetResponses, nextCursor, timeline.size() == size);
+        } finally {
+            DataSourceConfig.clearShard();
+        }
     }
 } 

--- a/src/main/java/com/example/demo/util/cassandra/CassandraDataController.java
+++ b/src/main/java/com/example/demo/util/cassandra/CassandraDataController.java
@@ -1,0 +1,113 @@
+package com.example.demo.util.cassandra;
+
+import com.example.demo.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 카산드라 팔로우 관계 테스트 데이터 생성 REST API
+ * 
+ * 사용 예시:
+ * POST /cassandra/data/generate-follows?userCount=1000001
+ * GET /cassandra/data/statistics
+ * DELETE /cassandra/data/clear
+ */
+@Slf4j
+@RestController
+@RequestMapping("/cassandra/data")
+@RequiredArgsConstructor
+public class CassandraDataController {
+
+    private final CassandraDataGenerator dataGenerator;
+
+    /**
+     * 대용량 팔로우 관계 생성
+     * 
+     * @param userCount 총 유저 수 (기본값: 1000001)
+     */
+    @PostMapping("/generate-follows")
+    public ApiResponse<String> generateFollowRelations(
+            @RequestParam(defaultValue = "1000001") int userCount) {
+        
+        try {
+            log.info("팔로우 관계 생성 요청: 총 유저 수 {}", userCount);
+            
+            long startTime = System.currentTimeMillis();
+            dataGenerator.generateFollowRelations(userCount);
+            long endTime = System.currentTimeMillis();
+            
+            String message = String.format("팔로우 관계 생성 완료 (소요시간: %d초)", (endTime - startTime) / 1000);
+            log.info(message);
+            
+            return ApiResponse.success("팔로우 관계 생성 완료", message);
+            
+        } catch (Exception e) {
+            log.error("팔로우 관계 생성 실패", e);
+            return ApiResponse.fail("팔로우 관계 생성 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 팔로우 관계 통계 조회
+     */
+    @GetMapping("/statistics")
+    public ApiResponse<String> getStatistics() {
+        try {
+            log.info("카산드라 팔로우 데이터 통계 요청");
+            dataGenerator.logFollowStatistics();
+            return ApiResponse.success("통계 조회 완료", "로그를 확인해주세요");
+            
+        } catch (Exception e) {
+            log.error("통계 조회 실패", e);
+            return ApiResponse.fail("통계 조회 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 모든 팔로우 데이터 삭제
+     */
+    @DeleteMapping("/clear")
+    public ApiResponse<String> clearAllData() {
+        try {
+            log.info("카산드라 팔로우 데이터 삭제 요청");
+            
+            long startTime = System.currentTimeMillis();
+            dataGenerator.clearAllFollowData();
+            long endTime = System.currentTimeMillis();
+            
+            String message = String.format("데이터 삭제 완료 (소요시간: %d초)", (endTime - startTime) / 1000);
+            log.info(message);
+            
+            return ApiResponse.success("데이터 삭제 완료", message);
+            
+        } catch (Exception e) {
+            log.error("데이터 삭제 실패", e);
+            return ApiResponse.fail("데이터 삭제 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 테스트용 소규모 데이터 생성 (올바른 팔로워 수로 생성)
+     */
+    @PostMapping("/generate-test")
+    public ApiResponse<String> generateTestData() {
+        try {
+            log.info("테스트용 팔로우 관계 생성 요청 (올바른 팔로워 수로)");
+            
+            // 모든 Celebrity 유저의 팔로워를 지원하도록 충분한 유저 수 설정
+            long startTime = System.currentTimeMillis();
+            dataGenerator.generateFollowRelations(200000);  // 20만명으로 설정 (user_60의 10만 팔로워 + 여유분)
+            long endTime = System.currentTimeMillis();
+            
+            String message = String.format("테스트 데이터 생성 완료 (소요시간: %d초)", (endTime - startTime) / 1000);
+            log.info(message);
+            
+            return ApiResponse.success("테스트 데이터 생성 완료", message);
+            
+        } catch (Exception e) {
+            log.error("테스트 데이터 생성 실패", e);
+            return ApiResponse.fail("테스트 데이터 생성 실패: " + e.getMessage());
+        }
+    }
+} 

--- a/src/main/java/com/example/demo/util/cassandra/CassandraDataGenerator.java
+++ b/src/main/java/com/example/demo/util/cassandra/CassandraDataGenerator.java
@@ -1,0 +1,170 @@
+package com.example.demo.util.cassandra;
+
+import com.example.demo.domain.follow.FollowRepository;
+import com.example.demo.domain.follow.FollowersByUser;
+import com.example.demo.domain.follow.FollowersByUserKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 카산드라 팔로우 관계 테스트 데이터 생성기
+ * 
+ * 목적: 대용량 팔로우 관계 데이터를 효율적으로 생성
+ * 
+ * 데이터 구조:
+ * - 총 1,000,001명의 유저 (user_1 ~ user_1000001)
+ * - 7명의 Celebrity 유저가 각각 다른 수의 팔로워 보유:
+ *   user_10: 1명, user_20: 10명, user_30: 100명
+ *   user_40: 1,000명, user_50: 10,000명
+ *   user_60: 100,000명, user_70: 1,000,000명
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CassandraDataGenerator {
+
+    private final FollowRepository followRepository;
+
+    /**
+     * Celebrity 유저들의 팔로우 관계 생성
+     * 
+     * @param totalUserCount 총 유저 수 (1,000,001 권장)
+     */
+    public void generateFollowRelations(int totalUserCount) {
+        log.info("=== 카산드라 팔로우 관계 생성 시작 ===");
+        log.info("총 유저 수: {}", totalUserCount);
+        
+        LocalDateTime now = LocalDateTime.now();
+        
+        // Celebrity 유저와 팔로워 수 정의 (User 60까지 테스트)
+        int[][] celebrityFollowers = {
+            {10, 1},        // user_10: 1명
+            {20, 10},       // user_20: 10명  
+            {30, 100},      // user_30: 100명
+            {40, 1000},     // user_40: 1,000명
+            {50, 10000},    // user_50: 10,000명
+            {60, 100000}    // user_60: 100,000명 🚀
+        };
+        
+        for (int[] celebrity : celebrityFollowers) {
+            int celebrityNumber = celebrity[0];
+            int followerCount = celebrity[1];
+            
+            UUID celebrityId = generateUserId(celebrityNumber);
+            log.info("Celebrity user_{} ({}): {}명의 팔로워 생성 중...", 
+                celebrityNumber, celebrityId, followerCount);
+            
+            createFollowersForCelebrity(celebrityId, celebrityNumber, followerCount, totalUserCount, now);
+            
+            log.info("Celebrity user_{} 팔로워 생성 완료", celebrityNumber);
+        }
+        
+        log.info("=== 카산드라 팔로우 관계 생성 완료 ===");
+    }
+    
+    /**
+     * 특정 Celebrity에 대한 팔로워 생성
+     */
+    private void createFollowersForCelebrity(UUID celebrityId, int celebrityNumber, 
+                                           int followerCount, int totalUserCount, LocalDateTime now) {
+        
+        List<FollowersByUser> followers = new ArrayList<>();
+        int startFollower = getFollowerStartNumber(celebrityNumber);
+        int batchSize = 1000; // 배치 크기
+        
+        for (int i = 0; i < followerCount; i++) {
+            int followerNumber = startFollower + i;
+            
+            // 유효한 범위 내의 팔로워만 생성
+            if (followerNumber > totalUserCount) {
+                log.warn("팔로워 번호가 총 유저 수를 초과: {}", followerNumber);
+                break;
+            }
+            
+            UUID followerId = generateUserId(followerNumber);
+            
+            FollowersByUser follower = new FollowersByUser(celebrityId, followerId, now);
+                    
+            followers.add(follower);
+            
+            // 배치 단위로 저장
+            if (followers.size() >= batchSize) {
+                followRepository.saveAll(followers);
+                followers.clear();
+                
+                if (i % 10000 == 0) {
+                    log.info("진행률: {}/{}명 ({:.1f}%)", 
+                        i, followerCount, (double)i/followerCount*100);
+                }
+            }
+        }
+        
+        // 남은 데이터 저장
+        if (!followers.isEmpty()) {
+            followRepository.saveAll(followers);
+        }
+    }
+    
+    /**
+     * 각 Celebrity의 팔로워 시작 번호 계산 (overlapping 방식으로 수정)
+     */
+    private int getFollowerStartNumber(int celebrityNumber) {
+        // 모든 Celebrity가 동일한 풀에서 팔로워를 가져가도록 수정 (overlap 허용)
+        switch (celebrityNumber) {
+            case 10: return 1;          // user_1
+            case 20: return 1;          // user_1 ~ user_10 (중복 허용)
+            case 30: return 1;          // user_1 ~ user_100 (중복 허용)
+            case 40: return 1;          // user_1 ~ user_1000 (중복 허용)
+            case 50: return 1;          // user_1 ~ user_10000 (중복 허용)
+            case 60: return 1;          // user_1 ~ user_100000 (중복 허용)
+            case 70: return 1;          // user_1 ~ user_1000000 (중복 허용)
+            default: return 1;
+        }
+    }
+    
+    /**
+     * 유저 번호로부터 UUID 생성 (일관된 UUID 생성)
+     */
+    private UUID generateUserId(int userNumber) {
+        // 일관된 UUID 생성을 위해 고정된 패턴 사용
+        String uuidString = String.format("550e8400-e29b-41d4-a716-%012d", userNumber);
+        return UUID.fromString(uuidString);
+    }
+    
+    /**
+     * 모든 팔로우 관계 삭제
+     */
+    public void clearAllFollowData() {
+        log.info("=== 카산드라 팔로우 데이터 정리 시작 ===");
+        followRepository.deleteAll();
+        log.info("=== 카산드라 팔로우 데이터 정리 완료 ===");
+    }
+    
+    /**
+     * 팔로우 관계 통계 조회
+     */
+    public void logFollowStatistics() {
+        log.info("=== 카산드라 팔로우 데이터 통계 ===");
+        
+        // Celebrity별 팔로워 수 확인
+        int[] celebrityNumbers = {10, 20, 30, 40, 50, 60};
+        
+        for (int celebrityNumber : celebrityNumbers) {
+            UUID celebrityId = generateUserId(celebrityNumber);
+            List<UUID> followerIds = followRepository.findByKeyFollowedUserId(celebrityId)
+                    .stream()
+                    .map(follower -> follower.getKey().getFollowerId())
+                    .toList();
+            int followerCount = followerIds.size();
+            log.info("user_{} ({}): {}명의 팔로워", celebrityNumber, celebrityId, followerCount);
+        }
+        
+        log.info("=== 통계 조회 완료 ===");
+    }
+} 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        show_sql: true
+        show_sql: false
         dialect: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
 

--- a/src/test/java/com/example/demo/domain/tweet/TweetTimelineComparisonTest.java
+++ b/src/test/java/com/example/demo/domain/tweet/TweetTimelineComparisonTest.java
@@ -1,0 +1,495 @@
+package com.example.demo.domain.tweet;
+
+import com.example.demo.common.ApiResponse;
+import com.example.demo.domain.follow.FollowRepository;
+import com.example.demo.domain.follow.FollowersByUser;
+import com.example.demo.domain.tweet.controller.TweetController;
+import com.example.demo.domain.tweet.request.CreateTweetRequest;
+import com.example.demo.domain.tweet.response.TweetListResponse;
+import com.example.demo.domain.tweet.service.TweetService;
+import com.example.demo.domain.tweet.service.TweetServiceAdvanced;
+import com.example.demo.domain.user.User;
+import com.example.demo.domain.user.UserRepository;
+import com.example.demo.util.UUID.UUIDUtil;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * 🚀 타임라인 조회 성능 비교 테스트
+ * 
+ * 목표:
+ * 1. TweetServiceAdvanced: Fan-out 시 Redis에도 캐싱 → 빠른 타임라인 조회
+ * 2. TweetService: Cassandra만 Fan-out → 일반 타임라인 조회
+ * 3. 의미 있는 데이터로 실제 성능 차이 측정
+ * 
+ * 테스트 시나리오:
+ * - 팔로워 1명이 50명을 팔로우
+ * - TweetServiceAdvanced로 25개 트윗 생성 (Redis 캐시됨)
+ * - TweetService로 25개 트윗 생성 (Redis 캐시 안됨)
+ * - 타임라인 조회 성능 비교
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TweetTimelineComparisonTest {
+
+    @Autowired
+    private TweetController tweetController;
+    
+    @Autowired
+    private TweetService tweetService;
+    
+    @Autowired
+    @Qualifier("tweetServiceAdvanced")
+    private TweetServiceAdvanced tweetServiceAdvanced;
+    
+    @Autowired
+    private UserRepository userRepository;
+    
+    @Autowired
+    private FollowRepository followRepository;
+    
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    // 테스트 데이터
+    private UUID testFollowerId;
+    private final List<UUID> cachedAuthorIds = new ArrayList<>();    // Redis 캐시되는 작성자들
+    private final List<UUID> nonCachedAuthorIds = new ArrayList<>(); // Redis 캐시 안되는 작성자들
+    private boolean testDataInitialized = false;
+    
+    // 테스트 규모
+    private static final int CACHED_AUTHORS = 25;     // Redis 캐시되는 작성자 수
+    private static final int NON_CACHED_AUTHORS = 25; // Redis 캐시 안되는 작성자 수
+    private static final int TWEETS_PER_AUTHOR = 5;   // 작성자당 트윗 수 상향하여 데이터량 증가
+    private static final int TOTAL_TIMELINE_TWEETS = (CACHED_AUTHORS + NON_CACHED_AUTHORS) * TWEETS_PER_AUTHOR; // 250개
+
+    @BeforeAll
+    static void beforeAll() {
+        System.out.println("\n🚀 === Fan-out + Redis 캐싱 vs Cassandra 직접 조회 성능 비교 ===");
+        System.out.println("📊 테스트 규모:");
+        System.out.println("   - Redis 캐시되는 작성자: " + CACHED_AUTHORS + "명 (TweetServiceAdvanced 사용)");
+        System.out.println("   - Redis 캐시 안되는 작성자: " + NON_CACHED_AUTHORS + "명 (TweetService 사용)");
+        System.out.println("   - 작성자당 트윗: " + TWEETS_PER_AUTHOR + "개");
+        System.out.println("   - 총 타임라인 트윗: " + TOTAL_TIMELINE_TWEETS + "개");
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("🧪 6단계: 동시성 부하 기반 p95/p99 비교 (캐시 히트)")
+    void step6_ConcurrentTimelineLoadBenchmark() throws InterruptedException, ExecutionException {
+        final int pageSize = 50;
+        final int concurrency = 50;         // 동시 사용자 수
+        final int requestsPerThread = 40;   // 스레드당 요청 수 (총 2,000회)
+
+        // 데이터 보장: 타임라인이 비어있다면 트윗을 추가 생성하여 충분한 데이터 확보
+        ApiResponse<TweetListResponse> initialRedis = tweetController.getUserTimelineOptimized(testFollowerId, null, pageSize);
+        ApiResponse<TweetListResponse> initialCass = tweetController.getUserTimeline(testFollowerId, null, pageSize);
+        if (initialRedis.getData().getTweets().isEmpty() || initialCass.getData().getTweets().isEmpty()) {
+            for (UUID authorId : cachedAuthorIds) {
+                for (int t = 0; t < TWEETS_PER_AUTHOR; t++) {
+                    CreateTweetRequest req = new CreateTweetRequest();
+                    req.setContent("concurrent-warmup-cached-" + t);
+                    tweetServiceAdvanced.createTweet(authorId, req);
+                }
+            }
+            for (UUID authorId : nonCachedAuthorIds) {
+                for (int t = 0; t < TWEETS_PER_AUTHOR; t++) {
+                    CreateTweetRequest req = new CreateTweetRequest();
+                    req.setContent("concurrent-warmup-noncached-" + t);
+                    tweetService.createTweet(authorId, req);
+                }
+            }
+        }
+
+        // 워밍업: 캐시 히트 보장
+        for (int i = 0; i < 200; i++) {
+            tweetController.getUserTimelineOptimized(testFollowerId, null, pageSize);
+        }
+
+        // Redis 캐시 히트 시나리오 측정
+        List<Long> redisLatencies = runConcurrentRequests(concurrency, requestsPerThread,
+                () -> measureOnce(() -> tweetController.getUserTimelineOptimized(testFollowerId, null, pageSize))
+        );
+
+        // Cassandra 직접 조회 시나리오 측정
+        List<Long> cassandraLatencies = runConcurrentRequests(concurrency, requestsPerThread,
+                () -> measureOnce(() -> tweetController.getUserTimeline(testFollowerId, null, pageSize))
+        );
+
+        // 통계 계산
+        double redisP50 = percentile(redisLatencies, 50);
+        double redisP95 = percentile(redisLatencies, 95);
+        double redisP99 = percentile(redisLatencies, 99);
+        double cassP50 = percentile(cassandraLatencies, 50);
+        double cassP95 = percentile(cassandraLatencies, 95);
+        double cassP99 = percentile(cassandraLatencies, 99);
+
+        System.out.println("\n🧪 === 동시성 부하 결과 (캐시 히트) ===");
+        System.out.println("요청 수: " + (long) concurrency * requestsPerThread + ", 동시성: " + concurrency + ", 페이지: " + pageSize);
+        System.out.println("Redis    p50/p95/p99: " + asMs(redisP50) + "/" + asMs(redisP95) + "/" + asMs(redisP99));
+        System.out.println("Cassandra p50/p95/p99: " + asMs(cassP50) + "/" + asMs(cassP95) + "/" + asMs(cassP99));
+
+        double p95Improvement = (cassP95 - redisP95) / cassP95 * 100.0;
+        double p99Improvement = (cassP99 - redisP99) / cassP99 * 100.0;
+        System.out.println("개선율 p95: " + String.format("%.1f%%", p95Improvement) + ", p99: " + String.format("%.1f%%", p99Improvement));
+
+        // 최소 검증: 충분한 표본 수를 확보
+        assertThat(redisLatencies.size()).isEqualTo((long) concurrency * requestsPerThread);
+        assertThat(cassandraLatencies.size()).isEqualTo((long) concurrency * requestsPerThread);
+    }
+
+    private static String asMs(double v) {
+        return String.format("%.1fms", v);
+    }
+
+    private static long measureOnce(Runnable action) {
+        long s = System.currentTimeMillis();
+        action.run();
+        return System.currentTimeMillis() - s;
+    }
+
+    private static List<Long> runConcurrentRequests(int concurrency, int requestsPerThread, Callable<Long> task)
+            throws InterruptedException, ExecutionException {
+        ExecutorService pool = Executors.newFixedThreadPool(concurrency);
+        try {
+            List<Future<List<Long>>> futures = new ArrayList<>();
+            for (int i = 0; i < concurrency; i++) {
+                futures.add(pool.submit(() -> {
+                    List<Long> latencies = new ArrayList<>(requestsPerThread);
+                    for (int j = 0; j < requestsPerThread; j++) {
+                        latencies.add(task.call());
+                    }
+                    return latencies;
+                }));
+            }
+            List<Long> all = new ArrayList<>(concurrency * requestsPerThread);
+            for (Future<List<Long>> f : futures) {
+                all.addAll(f.get());
+            }
+            return all;
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    private static double percentile(List<Long> samples, int p) {
+        if (samples.isEmpty()) return 0d;
+        List<Long> sorted = new ArrayList<>(samples);
+        Collections.sort(sorted);
+        int idx = Math.max(0, Math.min(sorted.size() - 1, (int) Math.ceil(p / 100.0 * sorted.size()) - 1));
+        return sorted.get(idx);
+    }
+
+    @BeforeEach
+    void setUp() {
+        if (testDataInitialized) {
+            return;
+        }
+        // Redis 초기화는 최초 1회만 수행 (Redis 히트 시나리오 유지를 위함)
+        if (redisTemplate.getConnectionFactory() != null) {
+            redisTemplate.getConnectionFactory().getConnection().flushDb();
+        }
+
+        System.out.println("\n🔄 테스트 데이터 준비 중...");
+        setupComparisonTestData();
+
+        // 데이터 정합성을 위한 대기
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        testDataInitialized = true;
+        System.out.println("✅ 테스트 데이터 준비 완료");
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("🔥 1단계: TweetServiceAdvanced로 트윗 생성 (Redis 캐시 포함)")
+    void step1_CreateTweetsWithRedisCache() {
+        System.out.println("\n📝 === 1단계: Redis 캐시 포함 트윗 생성 ===");
+        
+        long startTime = System.currentTimeMillis();
+        int createdTweets = 0;
+        
+        // TweetServiceAdvanced로 트윗 생성 (Cassandra + Redis 동시 Fan-out)
+        for (int authorIndex = 0; authorIndex < cachedAuthorIds.size(); authorIndex++) {
+            UUID authorId = cachedAuthorIds.get(authorIndex);
+            
+            for (int tweetIndex = 0; tweetIndex < TWEETS_PER_AUTHOR; tweetIndex++) {
+                CreateTweetRequest request = new CreateTweetRequest();
+                request.setContent("Redis캐시 작성자" + authorIndex + "의 트윗 #" + (tweetIndex + 1));
+                
+                tweetServiceAdvanced.createTweet(authorId, request);
+                createdTweets++;
+            }
+        }
+        
+        long elapsedTime = System.currentTimeMillis() - startTime;
+        
+        System.out.println("🚀 TweetServiceAdvanced 트윗 생성 완료:");
+        System.out.println("   - 생성된 트윗: " + createdTweets + "개");
+        System.out.println("   - 소요시간: " + elapsedTime + "ms");
+        System.out.println("   - Redis 캐시: 활성화됨 ✅");
+        
+        assertThat(createdTweets).isEqualTo(CACHED_AUTHORS * TWEETS_PER_AUTHOR);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("📝 2단계: TweetService로 트윗 생성 (Redis 캐시 없음)")
+    void step2_CreateTweetsWithoutRedisCache() {
+        System.out.println("\n📝 === 2단계: Redis 캐시 없이 트윗 생성 ===");
+        
+        long startTime = System.currentTimeMillis();
+        int createdTweets = 0;
+        
+        // TweetService로 트윗 생성 (Cassandra만 Fan-out)
+        for (int authorIndex = 0; authorIndex < nonCachedAuthorIds.size(); authorIndex++) {
+            UUID authorId = nonCachedAuthorIds.get(authorIndex);
+            
+            for (int tweetIndex = 0; tweetIndex < TWEETS_PER_AUTHOR; tweetIndex++) {
+                CreateTweetRequest request = new CreateTweetRequest();
+                request.setContent("일반 작성자" + authorIndex + "의 트윗 #" + (tweetIndex + 1));
+                
+                tweetService.createTweet(authorId, request);
+                createdTweets++;
+            }
+        }
+        
+        long elapsedTime = System.currentTimeMillis() - startTime;
+        
+        System.out.println("🗄️  TweetService 트윗 생성 완료:");
+        System.out.println("   - 생성된 트윗: " + createdTweets + "개");
+        System.out.println("   - 소요시간: " + elapsedTime + "ms");
+        System.out.println("   - Redis 캐시: 비활성화됨 ❌");
+        
+        assertThat(createdTweets).isEqualTo(NON_CACHED_AUTHORS * TWEETS_PER_AUTHOR);
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("⚡ 3단계: Redis 캐시 히트 상황에서의 타임라인 조회")
+    void step3_TimelineQueryWithRedisCache() {
+        System.out.println("\n📊 === 3단계: Redis 캐시 히트 타임라인 조회 ===");
+        
+        // 여러 번 측정하여 평균 계산
+        List<Long> responseTimes = new ArrayList<>();
+        int queryCount = 10; // 반복 횟수 증가로 평균값 안정화
+        
+        for (int i = 0; i < queryCount; i++) {
+            long startTime = System.currentTimeMillis();
+            
+            ApiResponse<TweetListResponse> response = 
+                tweetController.getUserTimelineOptimized(testFollowerId, null, 50);
+            
+            long elapsedTime = System.currentTimeMillis() - startTime;
+            responseTimes.add(elapsedTime);
+            
+            // 응답 검증
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.getData().getTweets()).isNotEmpty();
+        }
+        
+        double avgResponseTime = responseTimes.stream().mapToLong(Long::longValue).average().orElse(0.0);
+        
+        System.out.println("⚡ Redis 캐시 히트 조회 결과:");
+        System.out.println("   - 조회 횟수: " + queryCount + "회");
+        System.out.println("   - 평균 응답시간: " + String.format("%.1f", avgResponseTime) + "ms");
+        System.out.println("   - 조회된 트윗 수: " + responseTimes.size() + "회 모두 성공");
+        System.out.println("   - 캐시 상태: Redis 히트 ✅");
+        
+        // Redis 캐시 히트는 Cassandra보다 빨라야 함
+        assertThat(avgResponseTime).isLessThan(200.0);
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("🗄️  4단계: Cassandra 직접 조회 상황에서의 타임라인 조회")
+    void step4_TimelineQueryWithoutRedisCache() {
+        System.out.println("\n📊 === 4단계: Cassandra 직접 조회 타임라인 조회 ===");
+        
+        // 여러 번 측정하여 평균 계산
+        List<Long> responseTimes = new ArrayList<>();
+        int queryCount = 5;
+        
+        for (int i = 0; i < queryCount; i++) {
+            long startTime = System.currentTimeMillis();
+            
+            ApiResponse<TweetListResponse> response = 
+                tweetController.getUserTimeline(testFollowerId, null, 50);
+            
+            long elapsedTime = System.currentTimeMillis() - startTime;
+            responseTimes.add(elapsedTime);
+            
+            // 응답 검증
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.getData().getTweets()).isNotEmpty();
+        }
+        
+        double avgResponseTime = responseTimes.stream().mapToLong(Long::longValue).average().orElse(0.0);
+        
+        System.out.println("🗄️  Cassandra 직접 조회 결과:");
+        System.out.println("   - 조회 횟수: " + queryCount + "회");
+        System.out.println("   - 평균 응답시간: " + String.format("%.1f", avgResponseTime) + "ms");
+        System.out.println("   - 조회된 트윗 수: " + responseTimes.size() + "회 모두 성공");
+        System.out.println("   - 캐시 상태: 직접 조회 🗄️");
+        
+        // Cassandra 직접 조회는 Redis보다 느릴 것으로 예상
+        assertThat(avgResponseTime).isGreaterThan(0.0);
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("📈 5단계: 최종 성능 비교 및 결과 분석")
+    void step5_FinalPerformanceComparison() {
+        System.out.println("\n📈 === 최종 성능 비교 ===");
+        final int compareSize = 20;
+
+        // 데이터 준비 보장: 단독 실행 시에도 최소 compareSize 이상의 타임라인 데이터가 있도록 보장
+        int initialCount = tweetController.getUserTimeline(testFollowerId, null, compareSize).getData().getTweets().size();
+        if (initialCount < compareSize) {
+            // Redis 캐시 포함 트윗 생성
+            for (int authorIndex = 0; authorIndex < cachedAuthorIds.size(); authorIndex++) {
+                UUID authorId = cachedAuthorIds.get(authorIndex);
+                for (int tweetIndex = 0; tweetIndex < TWEETS_PER_AUTHOR; tweetIndex++) {
+                    CreateTweetRequest request = new CreateTweetRequest();
+                    request.setContent("Warmup Redis캐시 작성자" + authorIndex + " 트윗 #" + (tweetIndex + 1));
+                    tweetServiceAdvanced.createTweet(authorId, request);
+                }
+            }
+            // Redis 캐시 미사용 트윗 생성
+            for (int authorIndex = 0; authorIndex < nonCachedAuthorIds.size(); authorIndex++) {
+                UUID authorId = nonCachedAuthorIds.get(authorIndex);
+                for (int tweetIndex = 0; tweetIndex < TWEETS_PER_AUTHOR; tweetIndex++) {
+                    CreateTweetRequest request = new CreateTweetRequest();
+                    request.setContent("Warmup 일반 작성자" + authorIndex + " 트윗 #" + (tweetIndex + 1));
+                    tweetService.createTweet(authorId, request);
+                }
+            }
+        }
+
+        // 비교 페이지 크기(카산드라 기본 LIMIT 20과 맞춤)
+        // compareSize는 상단에서 final로 선언됨
+        // 평균 측정 횟수
+        int measureCount = 10;
+
+        // Redis 캐시 버전 측정 (평균)
+        long redisTotal = 0;
+        ApiResponse<TweetListResponse> redisResponse = null;
+        for (int i = 0; i < measureCount; i++) {
+            long start = System.currentTimeMillis();
+            redisResponse = tweetController.getUserTimelineOptimized(testFollowerId, null, compareSize);
+            redisTotal += (System.currentTimeMillis() - start);
+        }
+        long redisElapsedTime = redisTotal / measureCount;
+
+        // Cassandra 직접 조회 버전 측정 (평균)
+        long cassandraTotal = 0;
+        ApiResponse<TweetListResponse> cassandraResponse = null;
+        for (int i = 0; i < measureCount; i++) {
+            long start = System.currentTimeMillis();
+            cassandraResponse = tweetController.getUserTimeline(testFollowerId, null, compareSize);
+            cassandraTotal += (System.currentTimeMillis() - start);
+        }
+        long cassandraElapsedTime = cassandraTotal / measureCount;
+        
+        // 결과 일관성 검증
+        assertThat(redisResponse.isSuccess()).isTrue();
+        assertThat(cassandraResponse.isSuccess()).isTrue();
+        assertThat(redisResponse.getData().getTweets()).hasSize(compareSize);
+        assertThat(cassandraResponse.getData().getTweets()).hasSize(compareSize);
+        
+        // 성능 개선율 계산
+        double improvementPercentage = 0;
+        if (cassandraElapsedTime > 0) {
+            improvementPercentage = ((double)(cassandraElapsedTime - redisElapsedTime) / cassandraElapsedTime) * 100;
+        }
+        
+        System.out.println("\n📊 === 최종 성능 비교 결과 (평균) ===");
+        System.out.println("🗄️  Cassandra 직접 조회(평균): " + cassandraElapsedTime + "ms");
+        System.out.println("⚡ Redis 캐시 히트 조회(평균): " + redisElapsedTime + "ms");
+        System.out.println("📈 성능 개선: " + String.format("%.1f%%", improvementPercentage));
+        System.out.println("📋 조회된 트윗 수: " + redisResponse.getData().getTweets().size() + "개");
+        
+        System.out.println("\n✅ === 결론 ===");
+        if (improvementPercentage > 0) {
+            System.out.println("🚀 TweetServiceAdvanced + Redis 캐시가 더 빠릅니다!");
+            System.out.println("   💡 Fan-out-on-write 시 Redis 캐싱이 조회 성능을 크게 향상시킵니다.");
+        } else {
+            System.out.println("🤔 이번 테스트에서는 성능 차이가 명확하지 않습니다.");
+            System.out.println("   💡 더 많은 데이터나 반복 테스트로 차이를 확인해보세요.");
+        }
+        
+        // 최소한의 성능 검증
+        assertThat(redisElapsedTime).isLessThan(1000); // 1초 이내
+        assertThat(cassandraElapsedTime).isLessThan(2000); // 2초 이내
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.out.println("\n🎯 === 테스트 완료 ===");
+        System.out.println("✨ Redis Fan-out 캐싱의 효과가 검증되었습니다!");
+    }
+
+    // === 헬퍼 메서드들 ===
+
+    private void setupComparisonTestData() {
+        // 고유한 타임스탬프 생성 (중복 방지)
+        long timestamp = System.currentTimeMillis();
+        
+        // 테스트 팔로워 생성
+        testFollowerId = createTestUser("perf.user." + timestamp + "@test.com", "perf_user_" + timestamp);
+        
+        // Redis 캐시되는 작성자들 생성 (TweetServiceAdvanced 사용)
+        for (int i = 0; i < CACHED_AUTHORS; i++) {
+            UUID authorId = createTestUser("cached.author" + i + "." + timestamp + "@test.com", "cached_author" + i);
+            cachedAuthorIds.add(authorId);
+            createFollowRelation(testFollowerId, authorId);
+        }
+        
+        // Redis 캐시 안되는 작성자들 생성 (TweetService 사용)
+        for (int i = 0; i < NON_CACHED_AUTHORS; i++) {
+            UUID authorId = createTestUser("noncached.author" + i + "." + timestamp + "@test.com", "noncached_author" + i);
+            nonCachedAuthorIds.add(authorId);
+            createFollowRelation(testFollowerId, authorId);
+        }
+        
+        System.out.println("   📝 테스트 사용자 생성: 1명");
+        System.out.println("   👥 Redis 캐시 작성자: " + CACHED_AUTHORS + "명");
+        System.out.println("   👥 일반 작성자: " + NON_CACHED_AUTHORS + "명");
+        System.out.println("   🔗 팔로우 관계: " + (CACHED_AUTHORS + NON_CACHED_AUTHORS) + "개");
+    }
+
+    private UUID createTestUser(String email, String name) {
+        UUID userId = UUIDUtil.generate();
+        User user = new User(userId, name, email, "password123");
+        return userRepository.save(user).getUserId();
+    }
+
+    private void createFollowRelation(UUID followerId, UUID followedUserId) {
+        FollowersByUser follow = new FollowersByUser(followedUserId, followerId, LocalDateTime.now());
+        followRepository.save(follow);
+    }
+}


### PR DESCRIPTION
1단계: TweetServiceAdvanced로 트윗 생성 (Redis 캐시 포함)
TweetServiceAdvanced 트윗 생성 완료:
   - 생성된 트윗: 125개
   - 소요시간: 1304ms
   - Redis 캐시: 활성화됨

2단계: TweetService로 트윗 생성 (Redis 캐시 없음)
TweetService 트윗 생성 완료:
   - 생성된 트윗: 125개
   - 소요시간: 981ms
   - Redis 캐시: 비활성화됨

3단계: Redis 캐시 히트 상황에서의 타임라인 조회
Redis 캐시 히트 조회 결과:
   - 조회 횟수: 10회
   - 평균 응답시간: 1.8ms
   - 조회된 트윗 수: 10회 모두 성공
   - 캐시 상태: Redis 히트 

4단계: Cassandra 직접 조회 상황에서의 타임라인 조회
Cassandra 직접 조회 결과:
   - 조회 횟수: 5회
   - 평균 응답시간: 4.0ms
   - 조회된 트윗 수: 5회 모두 성공
   - 캐시 상태: 직접 조회

5단계: 최종 성능 비교 및 결과 분석
 Cassandra 직접 조회(평균): 2ms
 Redis 캐시 히트 조회(평균): 0ms
 성능 개선: 100.0%
 조회된 트윗 수: 20개
- 결과 차이가 크게 나지 않음 -

6단계: 동시성 부하 기반 percentile 95%, 99% 비교
요청 수: 2000, 동시성: 50, 페이지: 50
Redis    p50/p95/p99: 6.0ms/16.0ms/23.0ms
Cassandra p50/p95/p99: 8.0ms/25.0ms/36.0ms
개선율 p95: 36.0%, p99: 36.1%
- 요청 수를 늘렸는데도, 큰 차이를 보이지 않음